### PR TITLE
Changed style of recommendation field labels and items

### DIFF
--- a/sites/all/themes/dev/warmshowers_zen/css/pages/recommendation.css
+++ b/sites/all/themes/dev/warmshowers_zen/css/pages/recommendation.css
@@ -1,0 +1,15 @@
+/***
+ * Styles for the Recommendation feedback section
+ */
+
+/* float field labels */
+#content-area > div.node-type-trust-referral div.field-label {
+    float: left;
+    margin-right: 0.5em;
+}
+
+/* inline field items */
+#content-area > div.node-type-trust-referral div.field-label + div div {
+    overflow: hidden;
+}
+


### PR DESCRIPTION
Current labels and items on `/recommendation/feedback-xxx` are stacked
on top of each other. When a profile picture is present, the response
to `overall experience` appears below the picture whereas the label
appears to the right of the picture.

![Screenshot from 2013-03-23 14:41:54](https://f.cloud.github.com/assets/2688472/293348/5abb2074-935b-11e2-8178-259f5a31c575.png)

This CSS tweek simply floats the label so that the item is inlined and
looks more natural and readable. It should work on all browsers.

![Screenshot from 2013-03-23 14:43:27](https://f.cloud.github.com/assets/2688472/293349/74ecdeec-935b-11e2-9b3b-2900463db5fa.png)

I took out the profile pic in the examples for privacy so it makes it look like the float would overlap the pic, but it doesn't. I just didn't have time to make a better example.
