### PR TITLE
Mark as available and notify all users whose 'become available' date passed

### DIFF
--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -2659,25 +2659,25 @@ function _wsuser_process_users_that_become_available() {
     'SELECT u.mail, u.language, u.uid
     FROM {users} u, {wsuser} ws
     WHERE u.uid = ws.uid
-    AND ws.notcurrentlyavailable = %d
+    AND ws.notcurrentlyavailable = 1
     AND ws.becomeavailable IS NOT NULL
+    AND ws.becomeavailable <> 0
     AND ws.becomeavailable < %d',
-    1, $now
+    $now
   );
 
-  // Notify these users that they are being marked as available to host.
+  // Update these users to available to host and notify them via email.
   $languages = language_list();
   while ($row = db_fetch_object($result)) {
+    // Update user to available to host.
+    db_query(
+      'UPDATE {wsuser}
+      SET notcurrentlyavailable = 0
+      WHERE uid = %d',
+      $row->uid
+    );
+
+    // Notify user via email that they are now marked as available to host.
     drupal_mail('wsuser', 'become_available_notification', $row->mail, $languages[$row->language], array('account' => user_load($row->uid)));
   }
-
-  // Update to available to host all unavailable users that set a 'become available' date that has passed.
-  db_query(
-    'UPDATE {wsuser}
-    SET notcurrentlyavailable = %d
-    WHERE notcurrentlyavailable = %d
-    AND becomeavailable IS NOT NULL
-    AND becomeavailable < %d',
-    0, 1, $now
-  );
 }


### PR DESCRIPTION
As a cron job, mark as available to host all users whose 'become available'
date has passed, and notify them via email of this change. RE: Issue #309
