### PR TITLE
Issue #307: Show availability status on profile more clearly

### DIFF
--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -2211,6 +2211,8 @@ function wsuser_preprocess(&$variables, $key) {
   if (user_access('administer users')) {
     $personal_stats['uid'] = t('UID: %uid', array('%uid' => $account->uid));
   }
+  $return_date = $account->becomeavailable ? format_date($account->becomeavailable, 'custom', 'Y-m-d') : t('not specified');
+  $personal_stats['availability'] = empty($account->notcurrentlyavailable) ? t('Currently Available') : t('Not Currently Available - expected return @date', array('@date' => $return_date));
 
   $variables += array(
     'account' => $account,
@@ -2241,6 +2243,7 @@ function wsuser_preprocess(&$variables, $key) {
     'is_self' => $account->uid == $GLOBALS['user']->uid,
 		"global_stats" => $global_stats,
 		"personal_stats" => $personal_stats,
+    'return_date' => $return_date,
   );
 
 

--- a/docroot/sites/all/themes/dev/warmshowers_zen/templates/user-profile.tpl.php
+++ b/docroot/sites/all/themes/dev/warmshowers_zen/templates/user-profile.tpl.php
@@ -66,7 +66,7 @@
     <div id="host-services">
       <h2><?php print t('Hosting information'); ?></h2>
       <?php if ($notcurrentlyavailable) : ?>
-        <?php print t('This member has marked themselves as not currently available for hosting, so their hosting information is not displayed'); ?>
+        <?php print t('This member has marked themselves as not currently available for hosting, so their hosting information is not displayed. <br/>Expected return @return.', array('@return' => $return_date)); ?>
       <?php else: ?>
         <?php foreach (array('preferred_notice', 'maxcyclists', 'bikeshop', 'campground', 'motel') as $item) : ?>
            <?php if (!empty($$item)): ?>


### PR DESCRIPTION
Simple addition of the return date on the list of personal attributes on the profile. They already get reminded every time they log in that they're not currently available.
