### PR TITLE
Fix #426 by not deleting the whole wsuser to do an update

### DIFF
--- a/docroot/sites/all/modules/dev/user_location/user_location.module
+++ b/docroot/sites/all/modules/dev/user_location/user_location.module
@@ -53,27 +53,27 @@ function _user_location_fieldlist() {
  * Adds registration form, validation, and insert
  */
 
-function user_location_user($op, &$edit, &$user, $category = NULL) {
+function user_location_user($op, &$edit, &$account, $category = NULL) {
   switch($op) {
     case 'register':
     case 'form':
       $GLOBALS['conf']['cache'] = FALSE;  // Prevent caching of registration page
-      return _user_location_form($edit, $user);  // Keyed array of fields
+      return _user_location_form($edit, $account);  // Keyed array of fields
 
     case 'validate':
-      _user_location_validate($edit, $user);
+      _user_location_validate($edit, $account);
       return;
 
     case 'insert':
       cache_clear_all(); // Might need to reset the used countries
     case 'update':
-      _user_location_save($edit, $user);
+      _user_location_save($edit, $account);
       return;
     case 'delete':
-      _user_location_delete($edit, $user);
+      _user_location_delete($edit, $account);
       return;
     case 'load':
-      _user_location_load($user);
+      _user_location_load($account);
 
   }
 }
@@ -326,17 +326,17 @@ function user_location_admin_settings_submit($form, &$form_state) {
 /**
  * Load user_location values and add to user
  *
- * @param unknown_type $user
+ * @param unknown_type $account
  */
-function _user_location_load(&$user) {
-  $res = db_query("SELECT * FROM {user_location} WHERE oid = %d", $user->uid);
+function _user_location_load(&$account) {
+  $res = db_query("SELECT * FROM {user_location} WHERE oid = %d", $account->uid);
   $location = array();
   unset($res->user);  // User should not be in there.
   if ($row = db_fetch_object($res)) {
     unset ($row->user); // User is a duplication in the user object
     foreach ($row as $key=> $value) {
       if ($key == 'country' || $key == 'province') { $value = strtolower($value); }  // Force all loewr case
-      $user->$key = $value;
+      $account->$key = $value;
     }
   }
 
@@ -364,10 +364,10 @@ function _user_location_validate($form, $user) { //CHANGEd all the $edits to $fo
  * After user profile form edit, save user_location
  *
  * @param unknown_type $edit
- * @param unknown_type $user
+ * @param unknown_type $account
  */
-function _user_location_save(&$edit, &$user) {
-  $user = user_load(array('uid'=>$user->uid));;
+function _user_location_save(&$edit, &$account) {
+  $account = user_load(array('uid'=>$account->uid));;
 
 
   // Only do geocoding if the location has been updated
@@ -375,12 +375,12 @@ function _user_location_save(&$edit, &$user) {
   // Or if it's not set or admin user is doing it
   if (array_key_exists('country',$edit) && array_key_exists('province',$edit)) {
     if ( (user_access('administer users') ||
-    $user->latitude == 0 || $user->source == 0 ||
-    ($edit['city'] != $user->city)
-    || ($edit['street'] != $user->street)
-    || ($edit['country'] != $user->country)
-    || ($edit['province'] != $user->province) )
-    && count($edit) && $user->source != 1 && ($edit['status'] == NULL || $edit['status']==1)) {
+    $account->latitude == 0 || $account->source == 0 ||
+    ($edit['city'] != $account->city)
+    || ($edit['street'] != $account->street)
+    || ($edit['country'] != $account->country)
+    || ($edit['province'] != $account->province) )
+    && count($edit) && $account->source != 1 && ($edit['status'] == NULL || $edit['status']==1)) {
       $geocoded_location = _user_location_geocode($edit);
       $source = $geocoded_location['source'];
       if ($source <= 8) {
@@ -389,9 +389,9 @@ function _user_location_save(&$edit, &$user) {
         $edit['longitude'] = $geocoded_location['longitude'];
         drupal_set_message(t("User location geocoded with accuracy %source", array('%source' => $source)));
         if ($source > 3) {
-          drupal_set_message(t("We were unable to completely determine your location. Please set your location using "). l(t("the Set Map Location tab"),"user/$user->uid/location"));
+          drupal_set_message(t("We were unable to completely determine your location. Please set your location using "). l(t("the Set Map Location tab"),"user/$account->uid/location"));
         } else {
-          drupal_set_message(t("Your map location has been determined from your address, but please check it using "). l(t("the Set Map Location tab"),"user/$user->uid/location"));
+          drupal_set_message(t("Your map location has been determined from your address, but please check it using "). l(t("the Set Map Location tab"),"user/$account->uid/location"));
         }
       }
     }
@@ -428,10 +428,10 @@ function _user_location_save(&$edit, &$user) {
   $query = "
     insert into {user_location} ($valuenames) values ( $placeholders )
     ON DUPLICATE KEY UPDATE  $updatestmt";
-  $values = array_merge(array($user->uid), $fieldlist_values,$fieldlist_values);
+  $values = array_merge(array($account->uid), $fieldlist_values,$fieldlist_values);
   $sqlresult = db_query($query, $values);
   if ($sqlresult == FALSE) {
-    watchdog('user_location',"Failed to save user data for user @uid. Query=@query", array('@uid'=>$user->uid, '@query'=>$query), WATCHDOG_ERROR, "user/{$user->uid}");
+    watchdog('user_location',"Failed to save user data for user @uid. Query=@query", array('@uid'=>$account->uid, '@query'=>$query), WATCHDOG_ERROR, "user/{$account->uid}");
     drupal_set_message(t("Sorry - your data was not saved. Please let the administrator know about this message"),'error');
   }
 }
@@ -440,11 +440,11 @@ function _user_location_save(&$edit, &$user) {
  * Delete user_location entry on user deletion
  *
  * @param unknown_type $edit
- * @param unknown_type $user
+ * @param unknown_type $account
  */
-function _user_location_delete($edit, $user) {
+function _user_location_delete($edit, $account) {
 
-  $uid = $user->uid;
+  $uid = $account->uid;
   $sqlresult = db_query("delete from {user_location} where oid = %d", $uid);
 
 }

--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -910,12 +910,12 @@ function _state_country_results($country, $province) {
 }
 
 
-function wsuser_load(&$user) {
-	$result = db_query('SELECT * FROM {wsuser} WHERE uid = %d', $user->uid);
+function wsuser_load(&$account) {
+	$result = db_query('SELECT * FROM {wsuser} WHERE uid = %d', $account->uid);
 	$row = db_fetch_object($result);
 	if ($row) {
 		foreach ($row as $key => $value) {
-			$user->$key = $value;
+			$account->$key = $value;
 		}
 	}
 }
@@ -1357,28 +1357,30 @@ function wsuser_validate(&$edit, $account)
 /**
  * Implementation of hook_user().
  */
-function wsuser_user($type, &$edit, &$user, $category = NULL)
+function wsuser_user($type, &$edit, &$account, $category = NULL)
 {
   switch ($type) {
     case 'load':
-      return wsuser_load($user);
+      wsuser_load($account);
+      return;
     case 'form':
     case 'register':
-      return wsuser_form($edit, $user, $category);
+      return wsuser_form($edit, $account, $category);
 
     case 'update':
     case 'insert':
-      return wsuser_save($edit, $user);
+      wsuser_save($edit, $account);
+      return;
     case 'view':
-      return wsuser_view($user);
+      return wsuser_view($account);
     case 'validate':
-      wsuser_validate($edit, $user);
+      wsuser_validate($edit, $account);
       return;
     case 'delete':
-      wsuser_delete($edit, $user);
+      wsuser_delete($edit, $account);
       return;
     case 'login':
-      wsuser_login($edit, $user);
+      wsuser_login($edit, $account);
       return;
   }
 }

--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -935,7 +935,8 @@ function wsuser_fieldlist() {
       'type' => 'textfield',
       'title' => t('Full Name'),
       'description' => t("Please enter your full name (including last name)"),
-      'required' => TRUE
+      'required' => TRUE,
+      'placeholder' => '"%s"',
     ),
     'comments' => array(
       'title' => t("About You"),
@@ -944,38 +945,45 @@ function wsuser_fieldlist() {
       'cols' => '40',
       'required' => TRUE,
       'description' => t("Please introduce yourself. Say something about your hosting capabilities, cycle touring experience, or your current trip if you're on one right now. <em><strong>You must put something descriptive here or your account will be deleted.</strong></em> Also, please mention any restrictive or distinctive things about you: Are you vegetarian? Have pets? Smoker? Allergies? "),
+      'placeholder' => '"%s"',
     ),
     'notcurrentlyavailable' => array(
       'type' => 'checkbox',
       'title' => t('Not Currently Available'),
       'description' => t('Check this if you are not currently available to host cyclists. Please add a note to the "About Me" section saying why you\'re not available to host, and remember to uncheck it when you become available. Checking this box leaves you off the map, and off most of the lists.'),
+      'placeholder' => '%d',
     ),
     'becomeavailable' => array(
       'type' => 'date',
       'title' => t('Will Become Available To Host'),
       'description' => t('If you are permanently unavailable to host, just set this to a date far in the future.'),
+      'placeholder' => '%d',
     ),
     'homephone' => array(
       'type' => 'textfield',
       'title' => t("Home Phone Number"),
+      'placeholder' => '"%s"',
     ),
     'mobilephone' => array(
       'type' => 'textfield',
       'title' => t("Mobile Phone"),
+      'placeholder' => '"%s"',
     ),
     'workphone' => array(
       'type' => 'textfield',
       'title' => t("Work Phone Number"),
+      'placeholder' => '"%s"',
     ),
-    'fax_number' => array(
-      'type' => 'textfield',
-      'title' => t("Fax Number"),
-    ),
+//    'fax_number' => array(
+//      'type' => 'textfield',
+//      'title' => t("Fax Number"),
+//      'placeholder' => '"%s"',
+//    ),
     'preferred_notice' => array(
       'type' => 'textfield',
       'title' => t('Preferred Notice'),
       'description' => t("If you require significant advance notice, please mention it here. <em>All cyclists should give as much notice as possible.</em>"),
-
+      'placeholder' => '"%s"',
     ),
     'maxcyclists' => array(
       'type' => 'select',
@@ -988,28 +996,33 @@ function wsuser_fieldlist() {
         4 => "4",
         5 => t("5 or more")
       ),
-
+      'placeholder' => '%d',
     ),
     'motel' => array(
       'type' => 'textfield',
       'title' => t("Distance to nearest hotel/motel"),
+      'placeholder' => '"%s"',
     ),
     'campground' => array(
       'type' => 'textfield',
       'title' => t("Distance to nearest campground"),
+      'placeholder' => '"%s"',
     ),
     'bikeshop' => array(
       'type' => 'textfield',
       'title' => t("Distance to nearest bike shop"),
+      'placeholder' => '"%s"',
     ),
     'languagesspoken' => array(
       'type' => 'textfield',
       'title' => t('Languages spoken'),
+      'placeholder' => '"%s"',
     ),
     'URL' => array(
       'type' => 'textfield',
       'title' => t("Website"),
       'description' => t("URL of your website, if any, in form http://yourwebsite.com. Leave it blank if you don't have one."),
+      'placeholder' => '"%s"',
     ),
     'offering_explanation' => array(
       'prefix' => '<div class="form-item"><label class="items-to-offer">',
@@ -1020,47 +1033,59 @@ function wsuser_fieldlist() {
     'bed' => array(
       'type' => 'checkbox',
       'title' => t('Bed'),
+      'placeholder' => '%d',
     ),
     'food' => array(
       'type' => 'checkbox',
       'title' => t('Food'),
+      'placeholder' => '%d',
     ),
     'laundry' => array(
       'type' => 'checkbox',
       'title' => t('Laundry'),
+      'placeholder' => '%d',
     ),
     'lawnspace' => array(
       'type' => 'checkbox',
       'title' => t('Lawn Space (for camping)'),
+      'placeholder' => '%d',
     ),
     'sag' => array(
       'type' => 'checkbox',
       'title' => t('SAG (vehicle support)'),
+      'placeholder' => '%d',
     ),
     'shower' => array(
       'type' => 'checkbox',
       'title' => t('Shower'),
+      'placeholder' => '%d',
     ),
     'storage' => array(
       'type' => 'checkbox',
       'title' => t('Storage'),
+      'placeholder' => '%d',
     ),
     'kitchenuse' => array(
       'type' => 'checkbox',
       'title' => t('Use of Kitchen'),
+      'placeholder' => '%d',
     ),
     'howdidyouhear' => array(
       'type' => 'textfield',
       'title' => t("Please let us know how you heard about WarmShowers.org"),
+      'placeholder' => '"%s"',
     ),
     'set_unavailable_timestamp' => array(
       'type' => 'hidden',
+      'placeholder' => '%d',
     ),
     'set_available_timestamp' => array(
       'type' => 'hidden',
+      'placeholder' => '%d',
     ),
     'last_unavailability_pester' => array(
       'type' => 'hidden',
+      'placeholder' => '%d',
     ),
 
   );
@@ -1160,13 +1185,12 @@ function wsuser_login_submit($form, &$form_state) {
 }
 
 /**
- * Consolidates work of hook_user()'s 'save'
+ * Consolidates work of hook_user()'s update and insert for a new user
  *
  * @param $edit
  * @param $user
- * @param $category
  */
-function wsuser_save(&$edit, &$account, $category)
+function wsuser_save(&$edit, &$account)
 {
   // Support values for when they changed their notcurrentlyavailable, etc.
 
@@ -1187,38 +1211,35 @@ function wsuser_save(&$edit, &$account, $category)
     drupal_set_message(t('You have unchecked "Not Currently Available" so your location will be shown on the map and you may receive guest requests.'));
   }
 
+  $wsuser_fields = wsuser_fieldlist();
+  $insert_fieldname_ary = array('uid');
+  $insert_placeholder_ary = array('%d');
+  $queryvalues = array();
+  $updatetext = "uid = %d,";
 
-  $placeholders = "%d,";
-  $valuenames = "uid,";
-  $values = array();
-  $values[] = $account->uid;
-  foreach (wsuser_fieldlist() as $item => $value) {
-    if ($value['type'] == 'fieldset' || $value['type'] == 'markup') {
-      continue;
+
+  foreach ($wsuser_fields as $key => $value) {
+    if (array_key_exists($key, $edit)) {
+      $insert_fieldname_ary[] = $key;
+      $insert_placeholder_ary[] = $value['placeholder'];
+      $queryvalues[] = $edit[$key];
+      $updatetext .= "$key = {$value['placeholder']},";
+      $edit[$key] = NULL;  // Required by hook_user so it knows the field has been done
     }
-    switch ($value['type']) {
-      case 'fieldset':
-      case 'markup':
-        continue;
-        break;
-      case 'date':
-      case 'hidden':  // Assumes hidden is an integer
-        $placeholders .= "%d,";
-        break;
-      default:
-        $placeholders .= "'%s',";
-        break;
-    }
-    $valuenames .= "$item ,";
-    $values[] = isset($edit[$item]) ? $edit[$item] : $account->$item;
   }
-  $placeholders = substr_replace($placeholders, "", -1);
-  $valuenames = substr_replace($valuenames, "", -1);
+  if (!empty($queryvalues)) {
+    $queryvalues = array_merge(array($account->uid), $queryvalues);
+    $updatetext = rtrim($updatetext, ',');
+    $query = 'INSERT INTO {wsuser} (' . implode(',', $insert_fieldname_ary) . ') VALUES (' . implode(',', $insert_placeholder_ary) .  ')';
+    $query .= ' ON DUPLICATE KEY UPDATE ' . $updatetext;
 
-  $uid = $account->uid;
-  $sqlresult = db_query("delete from {wsuser} where uid = %d", $uid);
-  $query = "insert into {wsuser} ($valuenames) values ( $placeholders ) ";
-  $sqlresult = db_query($query, $values);
+    // Provide doubled queryvalues because both insert and update will use it.
+    $double_query_values = array_merge($queryvalues, $queryvalues);
+    $result = db_query($query, $double_query_values);
+    if (!$result) {
+      watchdog('wsuser', "Failed update/insert, query=%query", array('%query' => $query), WATCHDOG_ERROR);
+    }
+  }
 }
 
 /**
@@ -1344,12 +1365,12 @@ function wsuser_user($type, &$edit, &$user, $category = NULL)
     case 'form':
     case 'register':
       return wsuser_form($edit, $user, $category);
+
     case 'update':
     case 'insert':
-      return wsuser_save($edit, $user, $category);
+      return wsuser_save($edit, $user);
     case 'view':
       return wsuser_view($user);
-
     case 'validate':
       wsuser_validate($edit, $user);
       return;

--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -1224,7 +1224,10 @@ function wsuser_save(&$edit, &$account)
       $insert_placeholder_ary[] = $value['placeholder'];
       $queryvalues[] = $edit[$key];
       $updatetext .= "$key = {$value['placeholder']},";
-      $edit[$key] = NULL;  // Required by hook_user so it knows the field has been done
+      // Setting $edit[$key] to NULL removes it from $user->data. However, there
+      // are many features in this site that assume this stuff will be in the normally-loaded
+      // global $user, so not doing this at this point. rfay 20150129
+      // $edit[$key] = NULL;  // Required by hook_user so it knows the field has been done
     }
   }
   if (!empty($queryvalues)) {

--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -1204,7 +1204,7 @@ function wsuser_save(&$edit, &$account)
   }
   // Otherwise, if they're switching from not available, set this as the beginning
   // of the availability cycle, and unset the other stuff.
-  else if (empty($edit['notcurrentlyavailable']) && (!empty($account->notcurrentlyavailable) || !isset($account->notcurrentlyavailable))) {
+  else if (array_key_exists('notcurrentlyavailable', $edit) && empty($edit['notcurrentlyavailable']) && (!empty($account->notcurrentlyavailable) || !isset($account->notcurrentlyavailable))) {
     $edit['set_available_timestamp'] = time();
     $edit['set_unavailable_timestamp'] = 0;
     $edit['last_unavailability_pester'] = 0;


### PR DESCRIPTION
This looks like the right approach to this to me. It keeps the old meta-definition of fields, but adds what's needed to construct a proper INSERT/UPDATE statement, instead of the delete+add that it was doing (from what year of dev? yuck!)

Note that the equivalent in user_location does *not* do this delete + insert thing, so should not suffer the same fate. And it also does what it should by setting the item to NULL. 