### PR TITLE
Hide remember me checkbox on user registration

### DIFF
--- a/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
+++ b/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
@@ -151,6 +151,25 @@ function warmshowers_site_user_profile_form_submit($form, &$form_state) {
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function warmshowers_site_form_user_register_form_alter(&$form, &$form_state) {
+  // We choose to hide the "remember me" checkbox on registration
+  // if persistent login won't do it for us per our submitted patch:
+  // https://www.drupal.org/node/765116
+  if (module_exists('logintoboggan')) {
+    if (variable_get('logintoboggan_immediate_login_on_register', TRUE)) {
+      if (isset($form['account']) && is_array($form['account'])) {
+        $form['account']['persistent_login']['#type'] = 'hidden';
+      }
+      else {
+        $form['persistent_login']['#type'] = 'hidden';
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_form_alter() to change the crazy handling in user_delete module().
  * We don't want people to have any choice but to delete it all.
  */


### PR DESCRIPTION
Address persistent_login patch previously applied in D6
Issue #491, #79
Reference: https://www.drupal.org/node/765116