### PR TITLE
Wrap node creation service in case of D6-style request

### DIFF
--- a/docroot/sites/all/modules/dev/ws_services/ws_services.module
+++ b/docroot/sites/all/modules/dev/ws_services/ws_services.module
@@ -218,3 +218,39 @@ function ws_services_services_account_object_alter(&$account) {
     $account->$key = $value;
   }
 }
+
+
+/**
+ * Implements hook_services_request_preprocess_alter()
+ *
+ * Attempts to capture a D6-style feedback creation POST and convert the members
+ * to D7-style.
+ *
+ * @param $controller
+ * @param $args
+ * @param $options
+ */
+function ws_services_services_request_preprocess_alter($controller, &$args, $options) {
+
+  // If this is a D6-style node creation, munch to the D7 style
+  if ($options['resource'] == 'node' && !empty($args[0]['node']['type']) && $args[0]['node']['type'] == "trust_referral") {
+    $args[0]['type'] = "trust_referral";
+    // was node[field_member_i_trust][0][uid][uid], now field_member_i_trust[und][0][uid]
+    $args[0]['field_member_i_trust']['und'][0]['uid'] = $args[0]['node']['field_member_i_trust'][0]['uid']['uid'];
+    // was node[body], now body[und][0][value]
+    $args[0]['body']['und'][0]['value'] = $args[0]['node']['body'];
+    // was node[field_guest_or_host][value], now field_guest_or_host[und]
+    $args[0]['field_guest_or_host']['und'] = $args[0]['node']['field_guest_or_host']['value'];
+    // was node[field_hosting_date][0][value][year] now field_hosting_date[und][0][value][year]
+    $args[0]['field_hosting_date']['und'][0]['value']['year'] = $args[0]['node']['field_hosting_date'][0]['value']['year'];
+    // was node[field_hosting_date][0][value][month] now field_hosting_date[und][0][value][month]
+    $args[0]['field_hosting_date']['und'][0]['value']['month'] = $args[0]['node']['field_hosting_date'][0]['value']['month'];
+    // Day of month is now required, but provide 15 as a filler
+    $args[0]['field_hosting_date']['und'][0]['value']['day'] = "15";
+    // Was node[field_rating][value], now field_rating[und]
+    $args[0]['field_rating']['und'] = $args[0]['node']['field_rating']['value'];
+
+    unset ($args[0]['node']);
+
+  }
+}


### PR DESCRIPTION
Node semantics have changed and this is an attempt to make apps be able to use the former values when doing a node creation service.