### PR TITLE
Fixes #649 by using the right fullname values, uses theme_username

### DIFF
--- a/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
+++ b/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
@@ -89,39 +89,20 @@ function warmshowers_site_theme() {
  * @return mixed
  */
 function warmshowers_site_preprocess(&$variables, $key) {
-  global $user;
-  if ($user) {
-    $variables['account'] = $user;
-  }
 
-  _warmshowers_site_get_theme_variables($key, $variables);
-}
-
-/**
- * Helper function to set default variables for theme functions.
- *
- * @param string $delta
- *  The delta name for the theme function being called.
- * @param array $variables
- *  An array of variables to be modified or appended to.
- *
- * @return array
- */
-function _warmshowers_site_get_theme_variables($delta, &$variables) {
-
-  switch ($delta) {
+  switch ($key) {
     case 'ws_user_account_menu':
-      if ($variables['account'] && !empty($variables['account']->uid)) {
-        $variables['fullname'] = $variables['account']->data['fullname'];
-        $variables['profile_link'] = isset($variables['account']->data['fullname']) ? l($variables['account']->data['fullname'], 'user/' . $variables['account']->uid) : '';
+      if (!empty($GLOBALS['user']->uid)) {
+        $account = user_load($GLOBALS['user']->uid);
+        $variables['profile_link'] = theme('username', array('account' => $account));
         if (module_exists('privatemsg') && function_exists('privatemsg_title_callback')) {
-          $variables['message_link'] = l(privatemsg_title_callback(), 'user/' . $variables['account']->uid . '/messages');
+          $variables['message_link'] = l(privatemsg_title_callback(), 'user/' . $GLOBALS['user']->uid . '/messages');
         }
         $variables['logout_link'] = l(t('Log out'), 'user/logout');
       }
       break;
     case 'ws_anonymous_user_menu':
-      if (!$variables['account'] || empty($variables['account']->uid)) {
+      if (empty($GLOBALS['user']->uid)) {
         $variables['signup_link'] = l(t('Sign up'), 'user/register', array(
           'attributes' => array(
             'class' => array('signup')


### PR DESCRIPTION
Fixes #649 - 

This attempts to resolve the confusion between $variables['account'] as used in user_profile.tpl.php and the info needed from $GLOBALS['user']. Hopefully it will work out OK.

I consolidated everything back into warmshowers_site_preprocess() because there was only the one call remaining in it.