### PR TITLE
Fixes #659 by doing check_markup with the correct filter format

### DIFF
--- a/docroot/sites/all/themes/warmshowers_zen/templates/user-profile.tpl.php
+++ b/docroot/sites/all/themes/warmshowers_zen/templates/user-profile.tpl.php
@@ -39,7 +39,8 @@
   <h1><?php print t('About this Member'); ?></h1>
 
   <div class="account-body">
-    <?php print check_markup($account->comments); ?>
+    <?php // the filter_format "filtered html" has machine name 1 in our upgraded drupal site ?>
+    <?php print check_markup($account->comments, 1); ?>
   </div>
 
   <?php // @TODO @TODO @TODO @TODO @TODO Aboslutely must render the full node.


### PR DESCRIPTION
Fixes #659 - 

check_markup() is different and requires a filter format (or uses the default, which is plain text). It turns out our upgraded site has a machine name of "1" for filtered_html. So that's what's used here.