### PR TITLE
Fixes #675 fullname lookup failure by doing user_load in wsuser_tokens()

### DIFF
--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -219,8 +219,8 @@ function wsuser_tokens($type, $tokens, $data = array(), $options = array()) {
 
   $replacements = array();
 
-  if ($type == 'user' && !empty($data['user'])) {
-    $account = $data['user'];
+  if ($type == 'user' && !empty($data['user']->uid)) {
+    $account = user_load($data['user']->uid);
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'fullname':
@@ -266,7 +266,6 @@ function wsuser_tokens($type, $tokens, $data = array(), $options = array()) {
         case 'city':
           $replacements[$original] = $sanitize ? filter_xss($account->city) : $account->city;
           break;
-
       }
 
     }


### PR DESCRIPTION
For #675 - 
Mostly I don't think that tokens will get looked up for ordinary situations, so this user_load (which is extraneous in cases where it's already loaded) should not be a perf hit. OTOH, it could check to see if some of the info was there before doing the user_load(). 