### PR TITLE
Fixes #705 by moving user location tokens into the right module

### DIFF
--- a/docroot/sites/all/modules/dev/user_location/user_location.module
+++ b/docroot/sites/all/modules/dev/user_location/user_location.module
@@ -1336,3 +1336,69 @@ function user_location_meters_to_miles_km($meters, $distance_unit) {
   );
 
 }
+
+/**
+ * Implements hook_token_info()
+ */
+function user_location_token_info() {
+  $tokens = array();
+
+  $tokens['user']['source'] = array(
+    'name' => t('Geocoding accuracy'),
+    'description' => t("Geocoding accuracy of location info"),
+  );
+  $tokens['user']['country'] = array(
+    'name' => t('Country'),
+    'description' => t("User's country")
+  );
+  $tokens['user']['province'] = array(
+    'name' => t('Province'),
+    'description' => t("User's province")
+  );
+  $tokens['user']['city'] = array(
+    'name' => 'City',
+    'description' => t("User's city")
+  );
+  return array('tokens' => $tokens);
+}
+
+/**
+ * Implements hook_tokens().
+ * @param $type
+ *   As in type of 'user'
+ * @param $tokens
+ *   Array of tokens to be replaced
+ * @param $data
+ *   Associative array of data objects to be replaced
+ * @param $options
+ *   An associative array of options for token replacement; see token_replace() for possible values.
+ * @return array
+ */
+function user_location_tokens($type, $tokens, $data = array(), $options = array()) {
+
+  $sanitize = !empty($options['sanitize']);
+
+  $replacements = array();
+
+  if ($type == 'user' && !empty($data['user']->uid)) {
+    $account = user_load($data['user']->uid);
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'source':
+          $replacements[$original] = !empty($account->source) ? $account->source : NULL;
+          break;
+        case 'country':
+          $replacements[$original] = !empty($account->country) ? $account->country : NULL;
+          break;
+        case 'province':
+          $replacements[$original] = !empty($account->country) ? $account->province : NULL;
+          break;
+        case 'city':
+          $replacements[$original] = !empty($account->city) ? filter_xss($account->city) : NULL;
+          break;
+      }
+    }
+  }
+  return $replacements;
+}
+

--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -244,20 +244,6 @@ function wsuser_tokens($type, $tokens, $data = array(), $options = array()) {
         case 'servicesoffered':
           $replacements[$original] = _wsuser_account_services_list($account);
           break;
-
-        // TODO: source, country, province, city are user_location, not wsuser - should move there
-        case 'source':
-          $replacements[$original] = $account->source;
-          break;
-        case 'country':
-          $replacements[$original] = $sanitize ? check_plain($account->country) : $account->country;
-          break;
-        case 'province':
-          $replacements[$original] = $sanitize ? check_plain($account->province) : $account->province;
-          break;
-        case 'city':
-          $replacements[$original] = $sanitize ? filter_xss($account->city) : $account->city;
-          break;
       }
     }
   }
@@ -310,24 +296,6 @@ function wsuser_token_info() {
     'description' => t('Concatenated list of services offered'),
   );
 
-
-  // TODO: Country, province, city are actually functions of user_location and should be in its token implementation
-  $tokens['user']['source'] = array(
-    'name' => t('Geocoding accuracy'),
-    'description' => t("Geocoding accuracy of location info"),
-  );
-  $tokens['user']['country'] = array(
-    'name' => t('Country'),
-    'description' => t("User's country")
-  );
-  $tokens['user']['province'] = array(
-    'name' => t('Province'),
-    'description' => t("User's province")
-  );
-  $tokens['user']['city'] = array(
-    'name' => 'City',
-    'description' => t("User's city")
-  );
   return array('tokens' => $tokens);
 }
 


### PR DESCRIPTION
#705 reports that on user creation a number of tokens were causing PHP notices. Moving them to the right module, so the data will be there when needed, seems like a reasonable approach.