### PR TITLE
Re-add the userreference email token for CCK (#621) (D6)

### DIFF
--- a/docroot/sites/all/modules/patched/cck/includes/content.token.inc
+++ b/docroot/sites/all/modules/patched/cck/includes/content.token.inc
@@ -166,6 +166,7 @@ if (module_exists('userreference')) {
       $tokens['user reference']['link']  = t('Formatted HTML link to referenced user');
       $tokens['user reference']['path']  = t("Relative path alias to the referenced user.");
       $tokens['user reference']['url']  = t("Absolute path alias to the referenced user.");
+      $tokens['user reference']['mail'] = t('Referenced user email address');
 
       return $tokens;
     }
@@ -180,6 +181,9 @@ if (module_exists('userreference')) {
       $tokens['link']  = isset($item['view']) ? $item['view'] : '';
       $tokens['path'] = is_numeric($item['uid']) ? url('user/' . $item['uid']) : '';
       $tokens['url'] = is_numeric($item['uid']) ? url('user/' . $item['uid'], array('absolute' => TRUE)) : '';
+
+      $user = user_load(array('uid' => $item['uid']));
+      $tokens['mail'] = $user ? $user->mail : '';
 
       return $tokens;
     }

--- a/docroot/sites/all/modules/patched/cck/patches/cck.d6_add_user_reference_email.patch
+++ b/docroot/sites/all/modules/patched/cck/patches/cck.d6_add_user_reference_email.patch
@@ -1,0 +1,21 @@
+diff -u -r ./includes/content.token.inc /Users/rfay/workspace/warmshowers/docroot/sites/all/modules/patched/cck/includes/content.token.inc
+--- ./includes/content.token.inc	2011-01-05 03:34:57.000000000 -0700
++++ /Users/rfay/workspace/warmshowers/docroot/sites/all/modules/patched/cck/includes/content.token.inc	2015-08-31 15:55:59.000000000 -0600
+@@ -166,6 +166,7 @@
+       $tokens['user reference']['link']  = t('Formatted HTML link to referenced user');
+       $tokens['user reference']['path']  = t("Relative path alias to the referenced user.");
+       $tokens['user reference']['url']  = t("Absolute path alias to the referenced user.");
++      $tokens['user reference']['mail'] = t('Referenced user email address');
+ 
+       return $tokens;
+     }
+@@ -181,6 +182,9 @@
+       $tokens['path'] = is_numeric($item['uid']) ? url('user/' . $item['uid']) : '';
+       $tokens['url'] = is_numeric($item['uid']) ? url('user/' . $item['uid'], array('absolute' => TRUE)) : '';
+ 
++      $user = user_load(array('uid' => $item['uid']));
++      $tokens['mail'] = $user ? $user->mail : '';
++
+       return $tokens;
+     }
+   }


### PR DESCRIPTION
In #621 the problem with the lost email token on userreference is tracked down. 

This adds it back - 

It does the D6 only, by reapplying the old lost patch.
D7 still needs to be investigated and validated.