### PR TITLE
Fixes #707 by doing correct token for privatemsg URL.

### DIFF
--- a/docroot/sites/all/modules/patched/privatemsg/patches/privatemsg.configurable_menu_location_561036_83.patch
+++ b/docroot/sites/all/modules/patched/privatemsg/patches/privatemsg.configurable_menu_location_561036_83.patch
@@ -123,7 +123,7 @@ index 3a6ef68..6f5f5b2 100644
 \ No newline at end of file
 +}
 diff --git a/privatemsg.module b/privatemsg.module
-index 0d86e15..7f9a8d0 100755
+index 0d86e15..407efc2 100755
 --- a/privatemsg.module
 +++ b/privatemsg.module
 @@ -169,36 +169,44 @@ function _privatemsg_format_participants($part_array, $limit = NULL, $no_text =
@@ -427,6 +427,17 @@ index 0d86e15..7f9a8d0 100755
    if (!is_null($subject)) {
      // Explicitly encode the / so that it will be encoded twice to work around
      // the the menu_system.
+@@ -2891,8 +2986,8 @@ function privatemsg_tokens($type, $tokens, array $data = array(), array $options
+           break;
+ 
+         case 'url':
+-          $uri = entity_uri('privatemsg_message', $message);
+-          $replacements[$original] = url($uri['path'], $url_options + $uri['options']);
++          $path = privatemsg_get_dynamic_url_prefix() . '/view/' . $message->thread_id;
++          $replacements[$original] = url($path, $url_options);
+           break;
+ 
+         // Default values for the chained tokens handled below.
 diff --git a/privatemsg.pages.inc b/privatemsg.pages.inc
 index a26e74e..158fc9a 100644
 --- a/privatemsg.pages.inc

--- a/docroot/sites/all/modules/patched/privatemsg/privatemsg.module
+++ b/docroot/sites/all/modules/patched/privatemsg/privatemsg.module
@@ -2986,8 +2986,8 @@ function privatemsg_tokens($type, $tokens, array $data = array(), array $options
           break;
 
         case 'url':
-          $uri = entity_uri('privatemsg_message', $message);
-          $replacements[$original] = url($uri['path'], $url_options + $uri['options']);
+          $path = privatemsg_get_dynamic_url_prefix() . '/view/' . $message->thread_id;
+          $replacements[$original] = url($path, $url_options);
           break;
 
         // Default values for the chained tokens handled below.


### PR DESCRIPTION
Fixing #707: The token for privatemsg URL was broken. 
This is proposed upstream at https://www.drupal.org/node/561036#comment-10281917