### PR TITLE
Fixes #727 by reorganizing user_picture templates and theming

### DIFF
--- a/docroot/sites/all/modules/dev/wsuser/templates/wsuser-member-profile-highlight-block.tpl.php
+++ b/docroot/sites/all/modules/dev/wsuser/templates/wsuser-member-profile-highlight-block.tpl.php
@@ -11,7 +11,14 @@
 ?>
 <div class="profile-highlight">
   <div class="profile-image">
-    <?php print $user_picture; ?>
+    <?php
+    if (($account->uid != $GLOBALS['user']->uid) || !empty($account->picture)) {
+      print theme('user_picture', array('account' => $account, 'user_picture_style' => variable_get('user_picture_style_profiles', 'profile_picture')));
+    } else {
+      print '<p class="photo-scolding">' . t('You have not uploaded a picture yet. Please upload a picture to improve your chances to find hosts or guests. !link', array('!link' => l(t('Upload your picture by editing your profile.'), 'user/' . $account->uid . '/edit'))) . '</p>';
+
+    }
+    ?>
   </div>
 
   <div class="name-title">

--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -1743,13 +1743,6 @@ function wsuser_preprocess(&$variables, $key) {
   list($variables['pm_responsiveness'], $variables['pm_requests'], $variables['pm_responses'], $variables['pm_start_date'], $variables['pm_responsiveness_over_full_period']) = wsuser_privatemsg_responsiveness($account);
   $variables['pm_start_date'] = date('Y-m-d', $variables['pm_start_date']);
 
-  // Generate the theme account picture or the default picture,
-  // or a scolding message if it's the user themselves and none is present.
-  if (!empty($account->picture) || $account->uid != $GLOBALS['user']->uid) {
-    $variables['user_picture'] = theme('user_picture', array('account' => $account));
-  } else if ($account->uid == $GLOBALS['user']->uid) {
-    $variables['user_picture'] = '<p class="photo-scolding">' . t('You have not uploaded a picture yet. Please upload a picture to improve your chances to find hosts or guests. !link', array('!link' => l(t('Upload your picture by editing your profile.'), 'user/' . $account->uid . '/edit'))) . '</p>';
-  }
 }
 
 


### PR DESCRIPTION
Fixes #727 - confused user_picture preprocess and theming

There were a number of issues:

1. Since the main user profile picture got moved into member-profile-highlight-block, it was no longer being themed (and altered) by imagecache_profiles module, which acts on the user as it's rendered. So it got the wrong size.
2. The decision of whether to pester user about missing picture was being made in a generic user_picture preprocess, but that is used for many things other than the main block's picture. So the logic was moved into the block theming.
3. The warmshowers_zen_preprocess_user_profile() was hopelessly D6 still, really not accomplishing anything; it had calls to functions that don't exist in D7. 

I think that mostly you'll approve of this, @kalpaitch , but the logic added into wsuser-member-profile-highlight-block.tpl.php might give you heartburn. If it does, just suggest what I should do there. As mentioned, the user_picture preprocess can't be the place for it because that's used for many versions of the user picture.
