### PR TITLE
Fixes #574 by excluding UTF-8 characters that mysql/drupal can't handle

### DIFF
--- a/docroot/sites/all/modules/dev/wsuser/wsuser.module
+++ b/docroot/sites/all/modules/dev/wsuser/wsuser.module
@@ -1231,6 +1231,16 @@ function wsuser_form_user_profile_form_alter(&$form, &$form_state) {
 function _wsuser_user_form_validate($form, &$form_state) {
   $form_state['values']['URL'] = trim($form_state['values']['URL']);
 
+  // Remove 4-byte UTF-8 (emojis), which will break mysql insert. see http://stackoverflow.com/a/24672780/215713
+  $utf8_fixes = array('fullname', 'comments', 'URL', 'languagesspoken', 'mobilephone', 'workphone', 'homephone', 'preferred_notice', 'howdidyouhear');
+
+  foreach ($utf8_fixes as $item) {
+    if (!empty($form_state['values'][$item])) {
+      $form_state['values'][$item] = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $form_state['values'][$item]);
+    }
+  }
+
+
   if ($form_state['values']['URL'] && !valid_url($form_state['values']['URL'], TRUE)) {
     form_set_error('URL', t("Please enter a valid URL (with http:// on the front) for your website"));
   }


### PR DESCRIPTION
Fixes #574, the mysterious case where we had profiles coming through that were shorter than 15 words. 

It turns out to be a mysql + drupal problem, but the fix seems to be beyond Drupal at this point (See the issue). 

Since this problem is not just potentially for the "comments" field, I applied it in validation to all of the free-form text fields in wsuser. 