### PR TITLE
Fixes #698 by slimming down the /services/rest/message/get response

### DIFF
--- a/docroot/sites/all/modules/dev/privatemsg_services/privatemsg_services.module
+++ b/docroot/sites/all/modules/dev/privatemsg_services/privatemsg_services.module
@@ -100,8 +100,12 @@ function _privatemsg_services_get($type = 'inbox', $offset = NULL, $limit = NULL
 
   $messages = array();
   foreach ($msgs as $msg) {
-    $participants = privatemsg_thread_load($msg->thread_id);
-    $msg->participants = $participants['participants'];
+    $thread = privatemsg_thread_load($msg->thread_id);
+    $participants = array();
+    foreach ($thread['participants'] as $account) {
+      $participants[] = array('uid' => $account->uid, 'name' => $account->name, 'fullname' => $account->fullname);
+    }
+    $msg->participants = $participants;
 
     $messages[] = $msg;
   }


### PR DESCRIPTION
Fixing #698 

@klzig pointed out that the response was totally overkill (and exposed sensitive information). Simple fix here.

@chriscdn, you'll want to know that this happened.