### PR TITLE
Uc orders view: removing 'Orders' from profile menu tabs

### DIFF
--- a/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.features.inc
+++ b/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.features.inc
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * uc_orders_user_views.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function uc_orders_user_views_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.info
+++ b/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.info
@@ -1,0 +1,9 @@
+name = UC Orders User
+description = An update to the uc orders view to make sure it doesn't show as a user profile tab.
+core = 7.x
+package = Warmshowers.org Views
+dependencies[] = ctools
+dependencies[] = uc_order
+dependencies[] = views
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2

--- a/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.info
+++ b/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.info
@@ -5,5 +5,6 @@ package = Warmshowers.org Views
 dependencies[] = ctools
 dependencies[] = uc_order
 dependencies[] = views
+features[views_view][] = uc_orders_user
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2

--- a/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.module
+++ b/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the uc_orders_user_views feature.
+ */
+
+include_once 'uc_orders_user_views.features.inc';

--- a/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.views_default.inc
+++ b/docroot/sites/all/modules/dev/ws_views_features/modules/uc_orders_user_views/uc_orders_user_views.views_default.inc
@@ -1,0 +1,181 @@
+<?php
+/**
+ * @file
+ * uc_orders_user_views.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function uc_orders_user_views_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'uc_orders_user';
+  $view->description = '';
+  $view->tag = 'Ubercart';
+  $view->base_table = 'uc_orders';
+  $view->human_name = 'uc_orders_user';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'My order history';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['access']['perm'] = 'view own orders';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['query_comment'] = FALSE;
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '20';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['style_plugin'] = 'table';
+  $handler->display->display_options['style_options']['columns'] = array(
+    'created' => 'created',
+    'order_id' => 'order_id',
+    'actions' => 'order_id',
+    'order_status' => 'order_status',
+    'product_count' => 'product_count',
+    'order_total' => 'order_total',
+  );
+  $handler->display->display_options['style_options']['default'] = 'created';
+  $handler->display->display_options['style_options']['info'] = array(
+    'created' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'desc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'order_id' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => ' ',
+      'empty_column' => 0,
+    ),
+    'actions' => array(
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'order_status' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'product_count' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'order_total' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+  );
+  /* Field: Order: Creation date */
+  $handler->display->display_options['fields']['created']['id'] = 'created';
+  $handler->display->display_options['fields']['created']['table'] = 'uc_orders';
+  $handler->display->display_options['fields']['created']['field'] = 'created';
+  $handler->display->display_options['fields']['created']['label'] = 'Date';
+  $handler->display->display_options['fields']['created']['date_format'] = 'uc_store';
+  /* Field: Order: Order ID */
+  $handler->display->display_options['fields']['order_id']['id'] = 'order_id';
+  $handler->display->display_options['fields']['order_id']['table'] = 'uc_orders';
+  $handler->display->display_options['fields']['order_id']['field'] = 'order_id';
+  $handler->display->display_options['fields']['order_id']['label'] = 'Order #';
+  $handler->display->display_options['fields']['order_id']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['order_id']['link_to_order'] = 1;
+  /* Field: Order: Actions */
+  $handler->display->display_options['fields']['actions']['id'] = 'actions';
+  $handler->display->display_options['fields']['actions']['table'] = 'uc_orders';
+  $handler->display->display_options['fields']['actions']['field'] = 'actions';
+  /* Field: Order: Order status */
+  $handler->display->display_options['fields']['order_status']['id'] = 'order_status';
+  $handler->display->display_options['fields']['order_status']['table'] = 'uc_orders';
+  $handler->display->display_options['fields']['order_status']['field'] = 'order_status';
+  $handler->display->display_options['fields']['order_status']['label'] = 'Status';
+  /* Field: Order: Product count */
+  $handler->display->display_options['fields']['product_count']['id'] = 'product_count';
+  $handler->display->display_options['fields']['product_count']['table'] = 'uc_orders';
+  $handler->display->display_options['fields']['product_count']['field'] = 'product_count';
+  $handler->display->display_options['fields']['product_count']['label'] = 'Products';
+  /* Field: Order: Order total */
+  $handler->display->display_options['fields']['order_total']['id'] = 'order_total';
+  $handler->display->display_options['fields']['order_total']['table'] = 'uc_orders';
+  $handler->display->display_options['fields']['order_total']['field'] = 'order_total';
+  $handler->display->display_options['fields']['order_total']['label'] = 'Total';
+  $handler->display->display_options['fields']['order_total']['precision'] = '0';
+  /* Contextual filter: User: Uid */
+  $handler->display->display_options['arguments']['uid']['id'] = 'uid';
+  $handler->display->display_options['arguments']['uid']['table'] = 'users';
+  $handler->display->display_options['arguments']['uid']['field'] = 'uid';
+  $handler->display->display_options['arguments']['uid']['default_action'] = 'not found';
+  $handler->display->display_options['arguments']['uid']['exception']['value'] = '';
+  $handler->display->display_options['arguments']['uid']['default_argument_type'] = 'fixed';
+  $handler->display->display_options['arguments']['uid']['summary']['number_of_records'] = '0';
+  $handler->display->display_options['arguments']['uid']['summary']['format'] = 'default_summary';
+  $handler->display->display_options['arguments']['uid']['summary_options']['items_per_page'] = '25';
+  $handler->display->display_options['arguments']['uid']['specify_validation'] = TRUE;
+  $handler->display->display_options['arguments']['uid']['validate']['type'] = 'user_or_permission';
+  /* Filter criterion: Order: Order status */
+  $handler->display->display_options['filters']['order_status']['id'] = 'order_status';
+  $handler->display->display_options['filters']['order_status']['table'] = 'uc_orders';
+  $handler->display->display_options['filters']['order_status']['field'] = 'order_status';
+  $handler->display->display_options['filters']['order_status']['value'] = array(
+    '_active' => '_active',
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'user/%/orders';
+  $handler->display->display_options['menu']['title'] = 'Orders';
+  $handler->display->display_options['menu']['description'] = 'View your order history.';
+  $handler->display->display_options['menu']['weight'] = '0';
+  $handler->display->display_options['menu']['name'] = 'user-menu';
+  $handler->display->display_options['menu']['context'] = 0;
+  $handler->display->display_options['menu']['context_only_inline'] = 0;
+  $translatables['uc_orders_user'] = array(
+    t('Master'),
+    t('My order history'),
+    t('more'),
+    t('Apply'),
+    t('Reset'),
+    t('Sort by'),
+    t('Asc'),
+    t('Desc'),
+    t('Items per page'),
+    t('- All -'),
+    t('Offset'),
+    t('« first'),
+    t('‹ previous'),
+    t('next ›'),
+    t('last »'),
+    t('Date'),
+    t('Order #'),
+    t('Actions'),
+    t('Status'),
+    t('Products'),
+    t('.'),
+    t(','),
+    t('Total'),
+    t('All'),
+    t('Page'),
+  );
+  $export['uc_orders_user'] = $view;
+
+  return $export;
+}


### PR DESCRIPTION
@rfay Can you test this one out. Features didn't want to save this view even though it was listed as a legit feature component. It might be because it is already defined in code, but I've manually exported this and reverted and all seemed to be all right, would appreciate a test your end.