### PR TITLE
Fixes #804, confusion about default picture with mobile apps

### DIFF
--- a/docroot/sites/all/modules/dev/ws_services/ws_services.module
+++ b/docroot/sites/all/modules/dev/ws_services/ws_services.module
@@ -204,12 +204,10 @@ function _ws_services_hosts_by_keyword($data) {
 function _ws_services_profile_pictures($uri) {
   $profile_presets = variable_get('wsuser_profile_image_presets', array('mobile_profile_photo_std', 'profile_picture', 'mobile_photo_456', 'map_infoWindow'));
   $pictures = array();
-  if (empty($uri)) {
-    $uri = variable_get('user_picture_default');
-  }
 
   foreach ($profile_presets as $preset) {
-    $pictures["profile_image_{$preset}"] = image_style_url($preset, $uri);
+    // Return URL or empty if no picture.
+    $pictures["profile_image_{$preset}"] = !empty($uri) ? image_style_url($preset, $uri) : "";
   }
 
   return $pictures;

--- a/docroot/sites/all/modules/dev/wsmap/js/wsmap.js
+++ b/docroot/sites/all/modules/dev/wsmap/js/wsmap.js
@@ -287,6 +287,7 @@
        */
       Drupal.theme.prototype.wsmap_infoWindow = function (marker) {
         var html = '<div class="wsmap-infowindow">';
+        var default_picture = Drupal.settings.wsmap.user_picture_default;
         position = marker.host.position;
         hostcount = marker.hostcount;
         if (hostcount > 1) {
@@ -294,7 +295,9 @@
         }
         for (var i = 0; i < hostcount; i++) {
           var host = markers[markerPositions[position][i]].host;
-
+          if (!host.profile_image_map_infoWindow) {
+            host.profile_image_map_infoWindow = default_picture;
+          }
           html += '<div class="wsmap-infowindow-host">';
           html += '<div class="wsmap-infowindow-picture"><img src="' + host.profile_image_map_infoWindow + '"></div>';
           html += '<div class="wsmap-infowindow-hostinfo">';

--- a/docroot/sites/all/modules/dev/wsmap/wsmap.module
+++ b/docroot/sites/all/modules/dev/wsmap/wsmap.module
@@ -87,6 +87,7 @@ function wsmap_view($uid = NULL, $zoom = 0) {
       'maxZoom' => intval(variable_get('wsmap_clusterer_max_zoom', 6)),
       'gridSize' => intval(variable_get('wsmap_clusterer_grid_size', 50)),
     ),
+    'user_picture_default' => image_style_url('map_infoWindow', variable_get('user_picture_default', 'public://default_picture.jpg'))
   );
 
   if (!empty($uid)) {


### PR DESCRIPTION
For #804 -

When I tested the Android app I saw that since the server is filling in a default picture, we have ugly pictures on the app. The app wanted to provide its own picture. So this fix for the service has it returning empty picture strings. Updates the map js, since it uses that same technique, and *does* need the server-side default picture.