### PR TITLE
Stop caching dashboard map block (wsmap_view)

### DIFF
--- a/docroot/sites/all/modules/dev/wsmap/wsmap.module
+++ b/docroot/sites/all/modules/dev/wsmap/wsmap.module
@@ -231,6 +231,7 @@ function wsmap_block_info() {
 
   $blocks['wsmap_map'] = array(
     'info' => t('Warmshowers Google Map'),
+    'cache' => DRUPAL_NO_CACHE,
   );
   $blocks['wsmap_map_behaviors'] = array(
     'info' => t('Warmshowers Google Map Behaviors Block'),


### PR DESCRIPTION
There's a bug in Drupal core where js does not get added for a cached block, and the wsmap block was being cached, resulting in the map disappearing from the dashboard randomly. This PR makes it not cached. 

The drupal core issue for this is https://www.drupal.org/node/1460766