### PR TITLE
Fixes #789 by clearing field cache on privatemsg_message

### DIFF
--- a/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
+++ b/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
@@ -768,3 +768,17 @@ function warmshowers_site_unanswered_messages($account = NULL) {
   return $output;
 
 }
+
+/**
+ * Implements hook_field_attach_insert()
+ * See https://www.drupal.org/node/2577823 - this is a workaround for
+ * fields not showing up after being attached.
+ *
+ * @param $entity_type
+ * @param $entity
+ */
+function warmshowers_site_field_attach_insert($entity_type, $entity) {
+  if ($entity_type == 'privatemsg_message') {
+    cache_clear_all("field:privatemsg_message:{$entity->mid}", 'cache_field');
+  }
+}


### PR DESCRIPTION
Fixes #789 - 
The field cache needs to be cleared for the entity with fields added to it. This workaround seems to solve the problem. See also the privatemsg issue with patch: https://www.drupal.org/node/2577823#comment-10393949