### PR TITLE
FAQ node display

### DIFF
--- a/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.install
+++ b/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.install
@@ -320,3 +320,13 @@ function warmshowers_site_update_7018() {
     node_save($product);
   }
 }
+
+/**
+ * Turn off display of FAQ node type vocabulary
+ * Can't be done in features unfortunately
+ */
+function warmshowers_site_update_7019() {
+  $info = field_info_instance('node', 'taxonomy_vocabulary_6', 'faq');
+  $info['display']['default']['type'] = 'hidden';
+  field_update_instance($info);
+}

--- a/docroot/sites/all/modules/dev/ws_d7_upgrade_features/ws_d7_upgrade_features.info
+++ b/docroot/sites/all/modules/dev/ws_d7_upgrade_features/ws_d7_upgrade_features.info
@@ -223,6 +223,7 @@ features[variable][] = node_options_trust_referral
 features[variable][] = node_preview_block
 features[variable][] = node_preview_trust_referral
 features[variable][] = node_submitted_block
+features[variable][] = node_submitted_faq
 features[variable][] = node_submitted_trust_referral
 features[variable][] = robotstxt
 features[variable][] = search_active_modules

--- a/docroot/sites/all/modules/dev/ws_d7_upgrade_features/ws_d7_upgrade_features.strongarm.inc
+++ b/docroot/sites/all/modules/dev/ws_d7_upgrade_features/ws_d7_upgrade_features.strongarm.inc
@@ -472,6 +472,13 @@ function ws_d7_upgrade_features_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'node_submitted_faq';
+  $strongarm->value = 0;
+  $export['node_submitted_faq'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'node_submitted_trust_referral';
   $strongarm->value = 1;
   $export['node_submitted_trust_referral'] = $strongarm;


### PR DESCRIPTION
Fixes #838 - It turns out that fixing node settings for a contrib-provided node is a pain.

- Remove "submitted by" with a variable, in features. 
- Turn off display of vocabulary terms with field_update_instance()