### PR TITLE
Fix user location type field

### DIFF
--- a/docroot/sites/all/modules/dev/user_location/user_location.install
+++ b/docroot/sites/all/modules/dev/user_location/user_location.install
@@ -6,29 +6,11 @@
  */
 
 
-// $Id: user_location.install 505 2009-05-24 18:55:09Z rfay $
-
-
-// Consider adding the alter of tablename location to user_location here
-// Consider changing wsuser name here to wsuser_full_name
-// Load user_location_countries/provinces
-
-// Load geonames* ?
 /**
- * @todo Please document this function.
- * @see http://drupal.org/node/1354
+ * Remove the never-used field 'type' from table
  */
-function user_location_install() {
-  // Create tables.
-  // TODO The drupal_(un)install_schema functions are called automatically in D7.
-  // drupal_install_schema('user_location')
+function user_location_update_7001() {
+  if (db_field_exists('user_location', 'type')) {
+    db_drop_field('user_location', 'type');
+  }
 }
-
-function rename_location_table() {
-  $sql = "rename table location to user_location";
-  $result = db_query($sql);
-  return array('success' => $result !== FALSE, 'query' => check_plain($sql));
-
-}
-
-

--- a/docroot/sites/all/modules/dev/user_location/user_location.module
+++ b/docroot/sites/all/modules/dev/user_location/user_location.module
@@ -332,6 +332,9 @@ function user_location_user_load($accounts) {
   $result = db_query('SELECT * FROM {user_location} WHERE oid IN (:uids)', array(':uids' => array_keys($accounts)), array('fetch' => PDO::FETCH_OBJ));
   foreach ($result as $row) {
     foreach ($row as $key => $value) {
+      if ($key == 'oid') {
+        continue; // No need to load this field
+      }
       if ($key == 'country' || $key == 'province') {
         $value = strtolower($value);
       } // Force all lower case


### PR DESCRIPTION
Fixes #837, which just showed up as a PHP notice in privatemsg. I turned out that our very oldest users had something in this user_location 'type' field, and privatemsg uses that for its own (probably also a mistake).

- Drop the 'type' field from user_location
- Stop adding the 'oid' key from user_location into the user account object

Only 196 of our very original users had this field populated.

```
MariaDB [warmshowers_org]> SELECT COUNT(*),type FROM user_location GROUP BY type;
+----------+------+
| COUNT(*) | type |
+----------+------+
|    69144 |      |
|      196 | user |
+----------+------+
```