### PR TITLE
Fixes #881 by cleaning emojis out of privatemsg in the save process

### DIFF
--- a/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
+++ b/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
@@ -843,11 +843,25 @@ function warmshowers_site_field_attach_insert($entity_type, $entity) {
 
 
 /**
- * Implements hook_username_alter().
- * Change "name" to fullname for logged-in user
+ * Replace emojis and the like with "not found" character
+ *
+ * Works around long-term Drupal issue https://www.drupal.org/node/2488180
+ *
+ * @param $string
+ * @return string
  */
-//function warmshowers_site_username_alter(&$name, $account) {
-//  if (user_is_logged_in() && !empty($account->fullname)) {
-//    $name = $account->fullname;
-//  }
-//}
+function _warmshowers_site_strip_large_utf8($string) {
+  $result = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $string);
+  return $result;
+}
+
+/**
+ * Implements hook_privatemsg_message_presave_alter().
+ *
+ * Strip 4-byte UTF-8 from subject and body, since Drupal can't handle them.
+ */
+function warmshowers_site_privatemsg_message_presave_alter(&$message) {
+  foreach (array('subject', 'body') as $item) {
+    $message->$item = _warmshowers_site_strip_large_utf8($message->$item);
+  }
+}


### PR DESCRIPTION
Fixes #881 - this is the same ugly technique we used on user attributes.