### PR TITLE
Fixes #877 - experimental fix - allow loading privatemsg

### DIFF
--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -136,7 +136,7 @@ function ws_pm_email_notify_validate_routing($msg, $mid, $sender_uid, $their_mha
     return FALSE;
   }
 
-  $pm = privatemsg_message_load($mid);
+  $pm = privatemsg_message_load($mid, $sender_account);
 
   // Validate that we can find the pm
   if (empty($pm)) {
@@ -206,9 +206,9 @@ function ws_pm_email_notify_mandrill_incoming_event($event) {
     return array(array(MANDRILL_INCOMING_ERROR => $failure_description));
   }
 
-  $pm = privatemsg_message_load($mid);
-  $tid = $pm->thread_id;
   $sender_account = user_load($sender_uid);
+  $pm = privatemsg_message_load($mid, $sender_account);
+  $tid = $pm->thread_id;
 
   $text = $msg->text;
   // We have some messages with no text part. In that case, use html part.


### PR DESCRIPTION
For #877, messages lost when large batch comes in.

I will attempt to test this. I find it odd that this can work for the normal case, since it's loading the privatemsg on behalf of "no account"

AFAICT the failure is in ws_pm_email_notify_validate_routing(), line 139. We validate by trying to load the message, which clearly exists. But privatemsg_message_load() denies us; there seem to be no php errors associated.