### PR TITLE
Probably fixes #892 so we can't get missing arg on mandrill_incoming_event

### DIFF
--- a/docroot/sites/all/modules/contrib/mandrill_incoming/mandrill_incoming.module
+++ b/docroot/sites/all/modules/contrib/mandrill_incoming/mandrill_incoming.module
@@ -40,6 +40,7 @@ function mandrill_incoming_services_resources() {
         'source' => 'data',
         'description' => 'Incoming event data',
         'type' => 'array',
+        'optional' => 'false',
       ),
     ),
     'return' => 'bool',


### PR DESCRIPTION
Simple fix for trivial (apparently) #892 