### PR TITLE
919: Removed exit from node view access check on search indexing.

### DIFF
--- a/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
+++ b/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
@@ -751,7 +751,9 @@ function warmshowers_site_user_resource_login($username, $password) {
 function warmshowers_site_node_view_alter(&$build) {
   if (!user_is_logged_in() && $build['#node']->type == 'trust_referral') {
     drupal_not_found();
-    exit();
+    if ($build['#view_mode'] != 'search_index') {
+      drupal_exit();
+    }
   }
 }
 /**


### PR DESCRIPTION
Fixes: https://github.com/warmshowers/Warmshowers.org/issues/919