### PR TITLE
Followup to #879 - search-index not fully working

### DIFF
--- a/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
+++ b/docroot/sites/all/modules/dev/warmshowers_site/warmshowers_site.module
@@ -754,8 +754,8 @@ function warmshowers_site_user_resource_login($username, $password) {
  */
 function warmshowers_site_node_view_alter(&$build) {
   if (!user_is_logged_in() && $build['#node']->type == 'trust_referral') {
-    drupal_not_found();
     if ($build['#view_mode'] != 'search_index') {
+      drupal_not_found();
       drupal_exit();
     }
   }


### PR DESCRIPTION
Followup to #879, poor man's access control to feedback. @kalpaitch I just wanted to make sure this was what you had intended to do. The early drupal_not_found() was the cause of all the text and complaints in the indexing.