### PR TITLE
877: Added queue processing for mandrill incoming events.

### DIFF
--- a/docroot/.gitignore
+++ b/docroot/.gitignore
@@ -4,3 +4,4 @@ sites/*/settings*.php
 # Ignore paths that contain user-generated content.
 sites/*/files
 sites/*/private
+sites/*/translations

--- a/docroot/sites/all/modules/contrib/queue_ui/LICENSE.txt
+++ b/docroot/sites/all/modules/contrib/queue_ui/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/docroot/sites/all/modules/contrib/queue_ui/lib/QueueUI.php
+++ b/docroot/sites/all/modules/contrib/queue_ui/lib/QueueUI.php
@@ -1,0 +1,25 @@
+<?php
+
+
+class QueueUI {
+
+  /**
+   * Return the QueueUI class object for working with.
+   *
+   * @param $class
+   *  The queue class name to work with.
+   *
+   * @return mixte
+   *  The queue object for a given name, or FALSE if the QueueUI class does not exist for
+   *  the specified queue class.
+   */
+  public static function get($class) {
+    if (class_exists($class)) {
+      $object = new $class();
+      return $object;
+    }
+
+    // If class does not exist then QueueUI has not been implemented for this class.
+    return FALSE;
+  }
+}

--- a/docroot/sites/all/modules/contrib/queue_ui/lib/QueueUIInterface.php
+++ b/docroot/sites/all/modules/contrib/queue_ui/lib/QueueUIInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file
+ * Declares the Queue UI interface for inspecting queue data.
+ */
+
+interface QueueUIInterface {
+
+  /**
+   * Starting working with a Queue class.
+   */
+  public function __construct();
+
+  /**
+   * Inspect the queue items in a specified queue.
+   *
+   * @param string $queue_name
+   *  The name of the queue being inspected.
+   *
+   * @return
+   *  FALSE if inspection is not implemented for this queue class. Otherwise returns the
+   *  content to be rendered on the Queue inspection screen.
+   */
+  public function inspect($queue_name);
+
+  /**
+   * View item data for a specified queue item.
+   *
+   * @param integer $item_id
+   *  The item id to be viewed.
+   *
+   * @return
+   *  FALSE if viewing queue items is not implemented for this queue class. Otherwise returns
+   *  the content to be renders on the Queue item details screen.
+   */
+  public function view($item_id);
+
+  /**
+   * Force the deletion of a specified queue item.
+   *
+   * @param integer $item_id
+   *  The item id to be deleted.
+   *
+   * @return
+   *  TRUE if deletion succeeds, FALSE if deletion fails.
+   */
+  public function delete($item_id);
+
+  /**
+   * Force the releasing of a specified queue item.
+   *
+   * @param integer $item_id
+   *  The item id to be released.
+   *
+   * @return
+   *  TRUE if releasing succeeds, FALSE if releasing fails.
+   */
+  public function release($item_id);
+
+  /**
+   * Retrieve the available operations for the implementing queue class.
+   *
+   * @return
+   *  An array of the available operations for the implementing queue class.
+   */
+  public function getOperations();
+}

--- a/docroot/sites/all/modules/contrib/queue_ui/lib/QueueUISystemQueue.php
+++ b/docroot/sites/all/modules/contrib/queue_ui/lib/QueueUISystemQueue.php
@@ -1,0 +1,160 @@
+<?php
+
+class QueueUISystemQueue implements QueueUIInterface {
+
+  public $inspect;
+
+  public function __construct() {
+    $this->inspect = TRUE;
+  }
+
+  /**
+   * SystemQueue implements all default QueueUI methods.
+   *
+   * @return array
+   *  An array of available QueueUI methods. Array key is system name of the
+   *  operation, array key value is the display name.
+   */
+  public function getOperations() {
+    return array(
+      'view' => t('View'),
+      'release' => t('Release'),
+      'delete' => t('Delete'),
+    );
+  }
+
+  /**
+   * View the queue items in a queue and expose additional methods for inspection.
+   *
+   * @param string $queue_name
+   * @return string
+   */
+  public function inspect($queue_name) {
+    $query = db_select('queue', 'q')
+      ->fields('q', array('item_id', 'expire', 'created'))
+      ->condition('q.name', $queue_name)
+      ->extend('PagerDefault')
+      ->limit(25)
+      ->execute();
+
+    foreach ($query as $record) {
+      $result[] = $record;
+    }
+
+    $header = array(
+      t('Item ID'),
+      t('Expires'),
+      t('Created'),
+      array('data' => t('Operations'), 'colspan' => '3'),
+    );
+
+    $rows = array();
+    foreach ($result as $item) {
+      $row = array();
+      $row[] = $item->item_id;
+      $row[] = ($item->expire ? date(DATE_RSS, $item->expire) : $item->expire);
+      $row[] = date(DATE_RSS, $item->created);
+
+      foreach ($this->getOperations() as $op => $title) {
+        $row[] = l($title, QUEUE_UI_BASE . "/$queue_name/$op/$item->item_id");
+      }
+
+      $rows[] = array('data' => $row);
+    }
+
+    $content = theme('table', array('header' => $header, 'rows' => $rows));
+    $content .= theme('pager');
+
+    return $content;
+  }
+
+  /**
+   * View the item data for a specified queue item.
+   *
+   * @param int $item_id
+   * @return string
+   */
+  public function view($item_id) {
+    $queue_item = $this->loadItem($item_id);
+
+    $rows[] = array(
+      'data' => array(
+        'header' => t('Item ID'),
+        'data' => $queue_item->item_id,
+      ),
+    );
+    $rows[] = array(
+      'data' => array(
+        'header' => t('Queue name'),
+        'data' => $queue_item->name,
+      ),
+    );
+    $rows[] = array(
+      'data' => array(
+        'header' => t('Expire'),
+        'data' => ($queue_item->expire ? date(DATE_RSS, $queue_item->expire) : $queue_item->expire),
+      ),
+    );
+    $rows[] = array(
+      'data' => array(
+        'header' => t('Created'),
+        'data' => date(DATE_RSS, $queue_item->created),
+      ),
+    );
+    $rows[] = array(
+      'data' => array(
+        'header' => array('data' => t('Data'), 'style' => 'vertical-align:top'),
+        'data' => '<pre>' . print_r(unserialize($queue_item->data), TRUE) . '</pre>',
+        // @TODO - should probably do something nicer than print_r here...
+      ),
+    );
+
+    return theme('table', array('rows' => $rows));
+  }
+
+  public function delete($item_id) {
+    // @TODO - try... catch...
+    drupal_set_message("Deleted queue item " . $item_id);
+
+    db_delete('queue')
+      ->condition('item_id', $item_id)
+      ->execute();
+
+    return TRUE;
+  }
+
+  public function release($item_id) {
+    // @TODO - try... catch...
+    drupal_set_message("Released queue item " . $item_id);
+
+    db_update('queue')
+      ->condition('item_id', $item_id)
+      ->fields(array('expire' => 0))
+      ->execute();
+
+    return TRUE;
+  }
+
+  /**
+   * Load a specified SystemQueue queue item from the database.
+   *
+   * @param $item_id
+   *  The item id to load
+   * @return
+   *  Result of the database query loading the queue item.
+   */
+  private function loadItem($item_id) {
+    // Load the specified queue item from the queue table.
+    $query = db_select('queue', 'q')
+      ->fields('q', array('item_id', 'name', 'data', 'expire', 'created'))
+      ->condition('q.item_id', $item_id)
+      ->range(0, 1) // item id should be unique
+      ->execute();
+
+    foreach ($query as $record) {
+      $result[] = $record;
+    }
+
+    return $result[0];
+  }
+}

--- a/docroot/sites/all/modules/contrib/queue_ui/queue_ui.forms.inc
+++ b/docroot/sites/all/modules/contrib/queue_ui/queue_ui.forms.inc
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * View all the items in a queue.
+ */
+function queue_ui_view_queue($queue_name) {
+  if ($queue = _queue_ui_queueclass($queue_name)) {
+    return $queue->inspect($queue_name);
+  }
+}
+
+
+/**
+ * Display the details of an individual queue item.
+ */
+function queue_ui_view_queue_item($queue_name, $queue_item) {
+  if ($queue = _queue_ui_queueclass($queue_name)) {
+    return $queue->view($queue_item);
+  }
+  // @TODO - if not implemented display an error.
+}
+
+/**
+ * Releases an item from its queue by setting expiry to zero).
+ *
+ * @see queue_ui_release_item_submit()
+ */
+function queue_ui_release_item_form($form, $form_state, $queue_name, $queue_item) {
+  if ($queue = _queue_ui_queueclass($queue_name)) {
+    return confirm_form(
+      array(
+        'queue_item' => array(
+          '#type' => 'value',
+          '#value' => array('queue_name' => $queue_name, 'itemid' => $queue_item),
+        ),
+      ),
+      t('Are you sure you want to release queue item %queue_item?', array('%queue_item' => $queue_item)),
+      QUEUE_UI_BASE . "/inspect/$queue_name",
+      t('This action cannot be undone and will force the release of the item even if it is currently being processed.'),
+      t('Release item'),
+      t('Cancel')
+    );
+  }
+  // @TODO - if not implemented display an error.
+}
+
+/**
+ * Form submission handler for queue_ui_release_item_form().
+ */
+function queue_ui_release_item_form_submit($form, &$form_state) {
+  $queue_data = $form_state['values']['queue_item'];
+  $queue_name = $queue_data['queue_name'];
+
+  $queue = _queue_ui_queueclass($queue_name);
+  $queue->release($queue_data['itemid']);
+
+  $form_state['redirect'] = QUEUE_UI_BASE . "/inspect/$queue_name";
+}
+
+/**
+ * Delete a specified queue item.
+ */
+function queue_ui_delete_item_form($form, $form_state, $queue_name, $queue_item) {
+  if ($queue = _queue_ui_queueclass($queue_name)) {
+    return confirm_form(
+      array(
+        'queue_item' => array(
+          '#type' => 'value',
+          '#value' => array('queue_name' => $queue_name, 'itemid' => $queue_item),
+        ),
+      ),
+      t('Are you sure you want to delete queue item %queue_item?', array('%queue_item' => $queue_item)),
+      QUEUE_UI_BASE . "/inspect/$queue_name",
+      t('This action cannot be undone and will force the deletion of the item even if it is currently being processed.'),
+      t('Release item'),
+      t('Cancel')
+    );
+  }
+
+
+
+  // @TODO - if not implemented display an error.
+}
+
+/**
+ * Form submission handler for queue_ui_delete_item_form().
+ */
+function queue_ui_delete_item_form_submit($form, &$form_state) {
+  $queue_data = $form_state['values']['queue_item'];
+  $queue_name = $queue_data['queue_name'];
+
+  $queue = _queue_ui_queueclass($queue_name);
+  $queue->delete($queue_data['itemid']);
+
+  $form_state['redirect'] = QUEUE_UI_BASE . "/inspect/$queue_name";
+}

--- a/docroot/sites/all/modules/contrib/queue_ui/queue_ui.info
+++ b/docroot/sites/all/modules/contrib/queue_ui/queue_ui.info
@@ -1,0 +1,13 @@
+name = "Queue UI"
+description = "Interface and manager for Drupal queues"
+core = 7.x
+files[] = queue_ui.module
+files[] = lib/QueueUI.php
+files[] = lib/QueueUIInterface.php
+files[] = lib/QueueUISystemQueue.php
+; Information added by drupal.org packaging script on 2013-06-28
+version = "7.x-2.0-rc1"
+core = "7.x"
+project = "queue_ui"
+datestamp = "1372418751"
+

--- a/docroot/sites/all/modules/contrib/queue_ui/queue_ui.module
+++ b/docroot/sites/all/modules/contrib/queue_ui/queue_ui.module
@@ -1,0 +1,290 @@
+<?php
+
+/**
+ * @file queue_ui.module
+ */
+
+define('QUEUE_UI_BASE', 'admin/config/system/queue-ui');
+
+/**
+ * Implements hook_permission().
+ */
+function queue_ui_permission() {
+  return array(
+    'admin queue_ui' => array(
+      'title' => t('Administer queues'),
+      'description' => t('View, run, and delete queues'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_menu().
+ */
+function queue_ui_menu() {
+  $items[QUEUE_UI_BASE] = array(
+    'title' => 'Queue manager',
+    'description' => 'View and manage queues',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('queue_ui_page'),
+    'access arguments' => array('admin queue_ui'),
+    'file' => 'queue_ui.pages.inc',
+  );
+
+  $items[QUEUE_UI_BASE . '/inspect/%'] = array(
+    'title' => 'View Queue: @name',
+    'title arguments' => array('@name' => 5),
+    'page callback' => 'queue_ui_view_queue',
+    'page arguments' => array(5),
+    'access arguments' => array('admin queue_ui'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'queue_ui.forms.inc',
+  );
+
+  // View item callback for Queue UI.
+  $items[QUEUE_UI_BASE . '/%/view/%queue_ui_queue_item'] = array(
+    'title' => 'View Queue Item',
+    'description' => 'View the details of an individual queue item',
+    'page callback' => 'queue_ui_view_queue_item',
+    'page arguments' => array(4, 6),
+    'access arguments' => array('admin queue_ui'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'queue_ui.forms.inc',
+  );
+
+  // Release item callback for Queue UI.
+  $items[QUEUE_UI_BASE . '/%/release/%queue_ui_queue_item'] = array(
+    'title' => 'Release items',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('queue_ui_release_item_form', 4, 6),
+    'access arguments' => array('admin queue_ui'),
+    'file' => 'queue_ui.forms.inc',
+  );
+
+  // Delete item callback for Queue UI.
+  $items[QUEUE_UI_BASE . '/%/delete/%queue_ui_queue_item'] = array(
+    'title' => 'Release items',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('queue_ui_delete_item_form', 4, 6),
+    'access arguments' => array('admin queue_ui'),
+    'file' => 'queue_ui.forms.inc',
+  );
+
+  return $items;
+}
+
+/**
+ * Wildcard loader for queue_ui_queue.
+ */
+function queue_ui_queue_load($name) {
+  return DrupalQueue::get($name);
+}
+
+/**
+ * Wildcard loader for queue item.
+ *
+ * @param $queue_item
+ *   The item id of the queue item to load.
+ */
+function queue_ui_queue_item_load($queue_item) {
+  // @TODO - add validation of queue_item.
+  return $queue_item;
+}
+
+
+// @todo remove before prod
+function queue_ui_test() {
+  $queue = DrupalQueue::get('queue ui test_me');
+  $queue->createQueue();
+  $num = mt_rand(0,99);
+  for ($i = 0; $i < $num; $i++) {
+    $queue->createItem(time());
+  }
+}
+
+/**
+ * Retrieve the QueueUI object for the class a particular queue is implemented as.
+ *
+ * @param $queue_name
+ *  The name of the queue to retrieve the QueueUI class for.
+ * @return mixte
+ *  The QueueUI object for the relevant queue class, or FALSE if not found.
+ */
+function _queue_ui_queueclass($queue_name){
+  $queue = DrupalQueue::get($queue_name);
+  $class = get_class($queue);
+
+  return QueueUI::get('QueueUI' . $class);
+}
+
+/**
+ * Implements hook_queue_class_info.
+ *
+ * @return array of class information definitions.
+ */
+function queue_ui_queue_class_info() {
+  // Implement queue class info definitions for core Drupal queue classes.
+  return array(
+    'SystemQueue' => array(
+      'title' => t('System Queue (database Queue)'),
+      'inspect' => TRUE,
+      'operations' => array(
+        'view',
+        'release',
+        'delete',
+        'deleteall'),
+    ),
+    'MemoryQueue' => array(
+      'title' => t('Memory queue (non-reliable)'),
+      'inspect' => FALSE,
+    ),
+  );
+}
+
+/**
+ * Gets queues class info defined with hook_queue_class_info().
+ *
+ * @param string $class
+ *  The class name to retrieve
+ *
+ * @return Array of queue classes information.
+ */
+function queue_ui_get_queue_class_info($class) {
+  $classes = &drupal_static(__FUNCTION__);
+  if (!isset($classes)) {
+    // Invoke hook_queue_class_info().
+    $classes = module_invoke_all('queue_class_info');
+  }
+  return $classes[$class];
+}
+
+
+/**
+ * Get the names of queues.
+ *
+ * @param Array of queue names suitable for DrupalQueue::get();
+ */
+function queue_ui_queue_names() {
+  $result = db_query("SELECT DISTINCT name FROM {queue}");
+  return $result->fetchAll();
+}
+
+/**
+ * Get queues.
+ *
+ * @return Array of queues indexed by name and containing queue object and number
+ * of items.
+ */
+function queue_ui_queues() {
+  $queues = array();
+  $queue_names = queue_ui_queue_names();
+  if (!empty($queue_names)) {
+    // Build array of queues indexed by name with number of items.
+    foreach ($queue_names as $name) {
+      $queue = DrupalQueue::get($name->name);
+      $class = get_class($queue);
+      $queues[$class][$name->name] = array(
+        'queue' => $queue,
+        'items' => $queue->numberOfItems(),
+      );
+    }
+  }
+  return $queues;
+}
+
+/**
+ * Get queues defined with hook_queue_info().
+ *
+ * @return Array of queues indexed by name and containing
+ */
+function queue_ui_defined_queues() {
+  $queues = &drupal_static(__FUNCTION__);
+  if (!isset($queues)) {
+    // Invoke hook_queue_info().
+    $queues = module_invoke_all('queue_info');
+  }
+  return $queues;
+}
+
+/**
+ * Implements hook_cron().
+ */
+function queue_ui_cron() {
+  // Retrieve queues set for cron processing.
+  $defs = queue_ui_defined_queues();
+  if (!empty($defs)) {
+    foreach ($defs as $name => $definition) {
+      $queue = DrupalQueue::get($name);
+      // A cron callback must be defined and there must be items in the queue.
+      if (isset($definition['cron']) && is_object($queue) && $queue->numberOfItems()) {
+        $active = variable_get('queue_ui_cron_' . $name, FALSE);
+        if ($active) {
+          // Pass $queue to cron callback for processing.
+          $function = $definition['cron']['callback'];
+          // Definitions can define arguments.
+          $args = isset($definition['cron']['callback']) ? $definition['cron']['callback'] : NULL;
+          $function($queue, $args);
+        }
+      }
+    }
+  }
+}
+
+// @todo remove before prod
+function queue_ui_queue_info() {
+  return array(
+    'queue ui test_me' => array(
+      'title' => t('Test queue'),
+      'batch' => array(
+        'operations' => array(array('queue_ui_batch_test', array())),
+        'finished' => 'queue_ui_batch_finished',
+        'title' => t('Processing test queue'),
+      ),
+      'cron' => array(
+        'callback' =>'queue_ui_test_process',
+      ),
+    ),
+  );
+}
+
+function queue_ui_test_process($queue) {
+  $count = $queue->numberOfItems();
+  for ($i = 0; $i < 20 && $count > 0; $i++) {
+    $item = $queue->claimItem(20); // Lease time.
+    if ($item) {
+      // We would do some processing, if this were REAL.
+      $queue->deleteItem($item);
+      $count--;
+    }
+  }
+}
+
+function queue_ui_batch_test($queue, &$context) {
+  if (empty($context['sandbox'])) {
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['current'] = 0;
+    $context['sandbox']['max'] = $queue->numberOfItems();
+  }
+  for ($i = 0; $i < 20 && $context['sandbox']['current'] < $context['sandbox']['max']; $i++) {
+    $item = $queue->claimItem(20); // Lease time.
+    if ($item) {
+      // We would do some processing, if this were REAL.
+      $queue->deleteItem($item);
+    }
+    $context['sandbox']['progress']++;
+    $context['sandbox']['current']++;
+  }
+  if ($context['sandbox']['progress'] != $context['sandbox']['max']) {
+    $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+  }
+}
+
+function queue_ui_batch_finished($success, $results, $operations) {
+  if ($success) {
+    $message = 'success';
+  }
+  else {
+    $message = t('An error occured @todo.');
+  }
+  drupal_set_message($message);
+}

--- a/docroot/sites/all/modules/contrib/queue_ui/queue_ui.pages.inc
+++ b/docroot/sites/all/modules/contrib/queue_ui/queue_ui.pages.inc
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * @file queue_ui.pages.inc
+ */
+
+/**
+ * Queue form handler.
+ */
+function queue_ui_page($form, &$form_state) {
+  //queue_ui_test(); // @todo remove before prod
+  // Initialize.
+  if ($form_state['rebuild']) {
+    $form_state['input'] = array();
+  }
+  if (empty($form_state['storage'])) {
+    // First step, so start with our overview form.
+    $form_state['storage'] = array(
+      'step' => 'queue_ui_overview_form',
+    );
+  }
+  // Return the form from the current step.
+  $function = $form_state['storage']['step'];
+  $form = $function($form, $form_state);
+  return $form;
+}
+
+function queue_ui_page_submit($form, &$form_state) {
+  $values = $form_state['values'];
+  $queue_classes = _queue_ui_array_keys_contain($values, 'queues');
+
+  $queues = array();
+
+  foreach ($queue_classes as $class_name) {
+    foreach ($values[$class_name] as $queue) {
+      $queues[] = $queue;
+    }
+  }
+  // Get submitted queues to act on.
+  $queues = array_filter($queues);
+
+  if (empty($queues)) {
+    // Nothing to do.
+    return;
+  }
+  if (isset($values['step_submit'])) {
+    // Pass off to step submit handler.
+    $function = $values['step_submit'];
+    $function($form, $form_state, $queues);
+  }
+  return;
+}
+
+function queue_ui_overview_form() {
+  $queues = $options = array();
+  // @todo activation status
+  $header = array(
+    'name' => array('data' => t('Name')),
+    'title' => array('data' => t('Title')),
+    'items' => array('data' => t('Number of items')),
+    'class' => array('data' => t('Class')),
+    'inspect' => array('data' => t('Inspect')),
+     //'operations' => array('data' => t('Operations')),
+  );
+  // Get queues defined via our hook.
+  $defined_queues = queue_ui_defined_queues();
+  // Get queues names.
+  $queues = queue_ui_queues();
+
+  foreach ($queues as $class => $classed_queues) {
+    $options = array();
+
+    $class_info = QueueUI::get('QueueUI' . $class);
+
+    // Output information for each queue of the current class
+    foreach($classed_queues as $name => $queue) {
+      $title = '';
+      $operations = '';
+      $inspect = FALSE;
+
+      if (isset($defined_queues[$name])) {
+        $title = $defined_queues[$name]['title'];
+      }
+      if (isset($defined_queues[$name]['batch'])) {
+        $operations = 'batch';
+      }
+      if (is_object($class_info) && $class_info->inspect) {
+        $inspect = TRUE;
+      }
+
+      $options[$name] = array(
+        'name' => array('data' => $name),
+        'title' => array('data' => $title),
+        'items' => array('data' => $queue['items']),
+        'class' => array('data' => $class),
+        //'operations' => array('data' => $operations),
+      );
+
+      // If queue inspection is enabled for this class, add to the options array.
+      if ($inspect) {
+        $options[$name]['inspect'] = array('data' => l(t('Inspect'), QUEUE_UI_BASE . "/inspect/$name"));
+      }
+      else {
+        $options[$name]['inspect'] = '';
+      }
+    }
+
+    $form[$class] = array(
+      '#type' => 'fieldset',
+      '#collapsible' => TRUE,
+      '#title' => $class,
+     );
+
+    $form[$class]['queues_' . $class] = array(
+      '#type' => 'tableselect',
+      '#header' => $header,
+      '#options' => $options,
+      '#empty' => t('No queues exist for @class.', array('@class' => $class)),
+    );
+  }
+
+  // @todo deactivate options
+  // Option to run batch.
+  $form['batch'] = array(
+    '#type' => 'submit',
+    '#value' => t('Batch process'),
+  );
+  // Option to remove lease timestamps.
+  $form['release'] = array(
+    '#type' => 'submit',
+    '#value' => t('Remove leases'),
+  );
+  // Option to run via cron.
+  $form['cron'] = array(
+    '#type' => 'submit',
+    '#value' => t('Cron process'),
+  );
+  // Option to delete queue.
+  $form['delete'] = array(
+    '#type' => 'submit',
+    '#value' => t('Delete queues'),
+  );
+  // Specify our step submit callback.
+  $form['step_submit'] = array('#type' => 'value', '#value' => 'queue_ui_overview_submit');
+  return $form;
+}
+
+/**
+ * Overview submit handler.
+ */
+function queue_ui_overview_submit($form, &$form_state, $queues) {
+  $values = $form_state['values'];
+  // Switch off submitted action.
+  switch ($values['op']) {
+    case $values['cron']:
+      // Set variables for cron to TRUE.
+      $defined_queues = queue_ui_defined_queues();
+      $intersect = array_intersect(array_keys($defined_queues), $queues);
+      foreach ($intersect as $name) {
+        if (isset($defined_queues[$name]['cron'])) {
+          variable_set('queue_ui_cron_' . $name, TRUE);
+        }
+      }
+      break;
+    case $values['batch']:
+      // Process queue(s) with batch.
+      // We can only run batch on queues using our hook_queue_info() that define batch.
+      $defined_queues = queue_ui_defined_queues();
+      $intersect = array_intersect(array_keys($defined_queues), $queues);
+      foreach ($intersect as $name) {
+        // Only if queue_info implementation defined batch can we set it here.
+        if (isset($defined_queues[$name]['batch'])) {
+          $batch = $defined_queues[$name]['batch'];
+          // Add queue as argument to operations by resetting the operations array.
+          $operations = array();
+          $queue = DrupalQueue::get($name);
+          foreach ($batch['operations'] as $operation) {
+            // First element is the batch process callback, second is the argument.
+            $operations[] = array($operation[0], array_merge(array($queue), $operation[1]));
+          }
+          $batch['operations'] = $operations;
+          // Set.
+          batch_set($batch);
+        }
+      }
+      break;
+    case $values['delete']:
+      // Confirm before deleting. Go multistep!
+      $form_state['rebuild'] = TRUE;
+      $form_state['storage']['queues'] = $queues;
+      $form_state['storage']['step'] = 'queue_ui_confirm_delete';
+      break;
+    case $values['release']:
+      foreach ($queues as $name) {
+        $num_updated = db_update('queue')
+          ->fields(array(
+            'expire' => 0,
+          ))
+          ->condition('name', $name, '=')
+          ->execute();
+        drupal_set_message(t('!count lease reset in queue !name', array('!count' => $num_updated, '!name' => $name)));
+      }
+      break;
+  }
+  return;
+}
+
+/**
+ * Confirm form for deleting queues.
+ */
+function queue_ui_confirm_delete($form, &$form_state) {
+  $form['queues'] = array('#type' => 'value', '#value' => $form_state['storage']['queues']);
+  $description = t('All items in each queue will be deleted, regardless of if leases exist. This operation cannot be undone.');
+  // Specify our step submit callback.
+  $form['step_submit'] = array('#type' => 'value', '#value' => 'queue_ui_delete_submit');
+  return confirm_form($form,
+    format_plural(count($form_state['storage']['queues']), 'Are you sure you want to delete the queue?', 'Are you sure you want to delete @count queues?'),
+    'admin/config/system/queue-ui',
+    $description,
+    t('Delete'),
+    t('Cancel')
+  );
+}
+
+/**
+ * Submit handler for deleting queues.
+ */
+function queue_ui_delete_submit($form, &$form_state, $queues) {
+  $values = $form_state['values'];
+  $defined_queues = queue_ui_defined_queues();
+  foreach ($queues as $name) {
+    $queue = DrupalQueue::get($name);
+    if (isset($defined_queues[$name]['delete'])) {
+      $function = $defined_queues[$name]['delete'];
+      $function($queue);
+    }
+    $queue->deleteQueue();
+  }
+  drupal_set_message(format_plural(count($values['queues']), 'Queue deleted', '@count queues deleted'));
+  return;
+}
+
+function _queue_ui_array_keys_contain($input, $search_value, $strict = FALSE) {
+  $tmpkeys = array();
+
+  $keys = array_keys($input);
+
+  foreach ($keys as $k) {
+    if ($strict && strpos($k, $search_value) !== FALSE) {
+      $tmpkeys[] = $k;
+    }
+    elseif (!$strict && stripos($k, $search_value) !== FALSE) {
+      $tmpkeys[] = $k;
+    }
+  }
+
+  return $tmpkeys;
+}

--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -159,19 +159,6 @@ function ws_pm_email_notify_queue_insert($event) {
 }
 
 /**
- * Get an item from the queue.
- *
- * @return array
- */
-function ws_pm_email_notify_queue_claim() {
-  $queue = DrupalQueue::get('mandrill_incoming');
-  $queue->createQueue();
-
-  $item = $queue->claimItem();
-  return $item;
-}
-
-/**
  * The worker process for the queue
  */
 
@@ -184,13 +171,14 @@ function ws_pm_email_notify_queue_claim() {
  */
 function ws_pm_email_notify_queue_process($data = NULL) {
   if(empty($data)) {
-    $item = ws_pm_email_notify_queue_claim();
+    $queue = DrupalQueue::get('mandrill_incoming');
+    $queue->createQueue();
+
+    $item = $queue->claimItem();
     extract($item->data);
-    $type = 'manual';
   }
   else {
     extract($data);
-    $type = 'cron';
   }
 
   // All the logic previously handled in ws_pm_email_notify_mandrill_incoming_event
@@ -201,23 +189,18 @@ function ws_pm_email_notify_queue_process($data = NULL) {
     '@now' => strftime('%c', strtotime('now')),
     '%to' => print_r($event->msg->to, TRUE),
     '%subject' => $event->msg->subject,
-    '@type' => $type,
   );
 
   if ($handled === MANDRILL_INCOMING_HANDLED) {
-    watchdog('mandrill_incoming_queue', "Successfully processed (type=%type) incoming email (to=%to, subject=%subject) at @now.", $replacements, WATCHDOG_INFO);
-    $queue = DrupalQueue::get('mandrill_incoming');
-    $queue->createQueue();
+    watchdog('mandrill_incoming_queue', "Successfully processed incoming email (to=%to, subject=%subject) at @now.", $replacements, WATCHDOG_INFO);
 
     // If item has been claimed outside of the cron worker callback we need to remove it now, otherwise just continue.
     if (isset($item)) {
-      $queue->releaseItem($item);
+      $queue->deleteItem($item);
     }
   } else {
     // This item was not handled, we need to release it.
-    watchdog('mandrill_incoming_queue', "An incoming email (to=%to, subject=%subject) has failed processing (type=%type) at %now.", $replacements, WATCHDOG_INFO);
-    $queue = DrupalQueue::get('mandrill_incoming');
-    $queue->createQueue();
+    watchdog('mandrill_incoming_queue', "An incoming email (to=%to, subject=%subject) has failed processing at %now.", $replacements, WATCHDOG_INFO);
 
     // If item has been claimed outside of the cron worker callback we need to release it, otherwise throw an error.
     if (isset($item)) {

--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -41,7 +41,7 @@ function ws_pm_email_notify_admin_settings_form($form, &$form_state) {
   $form['pm_email_notify_processing']['process_item'] = array(
     '#type' => 'submit',
     '#value' => t('Process next item'),
-    '#submit' => array('ws_pm_email_notify_queue_claim'),
+    '#submit' => array('ws_pm_email_notify_queue_process'),
   );
 
   $form = system_settings_form($form);
@@ -129,7 +129,7 @@ function ws_pm_email_notify_queue_insert($event, $n = 0) {
     return FALSE;
   }
 
-  // Add this item to the queue
+  // Add this item to the queue.
   $record = array(
     'created' => REQUEST_TIME,
     'event' => $event,
@@ -142,25 +142,33 @@ function ws_pm_email_notify_queue_insert($event, $n = 0) {
 }
 
 /**
- * Insert item into the queue.
+ * Get an item from the queue.
  */
-function ws_pm_email_notify_queue_claim($item) {
-  if (empty($item)) {
-    $queue = DrupalQueue::get('digest_queue');
-    $queue->createQueue();
+function ws_pm_email_notify_queue_claim() {
+  $queue = DrupalQueue::get('mandrill_incoming');
+  $queue->createQueue();
 
-    $item = $queue->claimItem('digest_queue');
+  $item = $queue->claimItem();
+  return $item->data;
+}
+
+/**
+ * Process items from the queue.
+ */
+function ws_pm_email_notify_queue_process($item = NULL) {
+  if (empty($item)) {
+    $item = ws_pm_email_notify_queue_claim();
   }
 
-  if (!empty($item->data)) {
-    extract($item->data);
+  if (!empty($item)) {
+    extract($item);
   } else {
     return FALSE;
   }
 
   // All the logic previously handled in ws_pm_email_notify_mandrill_incoming_event
-  // is now processed by the queue function ws_pm_email_notify_queue_process.
-  $handled = empty($event) ? MANDRILL_INCOMING_UNHANDLED : ws_pm_email_notify_queue_process($event);
+  // is now processed by the queue function ws_pm_email_notify_process_event.
+  $handled = empty($event) ? MANDRILL_INCOMING_UNHANDLED : ws_pm_email_notify_process_event($event);
 
   if ($handled === MANDRILL_INCOMING_HANDLED) {
     watchdog(
@@ -174,6 +182,7 @@ function ws_pm_email_notify_queue_claim($item) {
       ),
       WATCHDOG_INFO
     );
+    $queue = DrupalQueue::get('mandrill_incoming');
     $queue->deleteItem($item);
   } else {
     // This item was not handled, we need to release it.
@@ -188,6 +197,7 @@ function ws_pm_email_notify_queue_claim($item) {
       ),
       WATCHDOG_INFO
     );
+    $queue = DrupalQueue::get('mandrill_incoming');
     $queue->releaseItem($item);
 
     // Notify admin. Possibly
@@ -196,6 +206,15 @@ function ws_pm_email_notify_queue_claim($item) {
   return $handled;
 }
 
+// hook_cron_queue_info()
+function ws_pm_email_notify_cron_queue_info() {
+  $queues['mandrill_incoming'] = array(
+    'worker callback' => 'ws_pm_email_notify_queue_claim',
+    'time' => 20
+  );
+
+  return $queues;
+}
 
 /** Begin section dealing with incoming messages ****/
 /**
@@ -319,7 +338,7 @@ function ws_pm_email_notify_mandrill_incoming_event($event) {
  * @return array|int
  * @throws Exception
  */
-function ws_pm_email_notify_queue_process($event) {
+function ws_pm_email_notify_process_event($event) {
   $ts = $event->ts; // Consider setting the event ts as the ts of the PM.
   $msg = $event->msg;
 

--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -179,16 +179,18 @@ function ws_pm_email_notify_queue_claim() {
  * Process items from the queue.
  *
  * @param array $data | NULL
- *  Required by the cron worker callback, should not be passed when running outside the cron worker callback.
+ *  Required only by the cron worker callback, should not be passed when running outside the cron worker callback.
  *  @see https://api.drupal.org/api/drupal/modules!system!system.api.php/function/callback_queue_worker/7
  */
 function ws_pm_email_notify_queue_process($data = NULL) {
   if(empty($data)) {
     $item = ws_pm_email_notify_queue_claim();
     extract($item->data);
+    $type = 'manual';
   }
   else {
     extract($data);
+    $type = 'cron';
   }
 
   // All the logic previously handled in ws_pm_email_notify_mandrill_incoming_event
@@ -199,11 +201,13 @@ function ws_pm_email_notify_queue_process($data = NULL) {
     '@now' => strftime('%c', strtotime('now')),
     '%to' => print_r($event->msg->to, TRUE),
     '%subject' => $event->msg->subject,
+    '@type' => $type,
   );
 
   if ($handled === MANDRILL_INCOMING_HANDLED) {
-    watchdog('mandrill_incoming_queue', "Successfully processed incoming email (to=%to, subject=%subject) at @now.", $replacements, WATCHDOG_INFO);
+    watchdog('mandrill_incoming_queue', "Successfully processed (type=%type) incoming email (to=%to, subject=%subject) at @now.", $replacements, WATCHDOG_INFO);
     $queue = DrupalQueue::get('mandrill_incoming');
+    $queue->createQueue();
 
     // If item has been claimed outside of the cron worker callback we need to remove it now, otherwise just continue.
     if (isset($item)) {
@@ -211,8 +215,9 @@ function ws_pm_email_notify_queue_process($data = NULL) {
     }
   } else {
     // This item was not handled, we need to release it.
-    watchdog('mandrill_incoming_queue', "An incoming email (to=%to, subject=%subject) has failed processing at %now.", $replacements, WATCHDOG_INFO);
+    watchdog('mandrill_incoming_queue', "An incoming email (to=%to, subject=%subject) has failed processing (type=%type) at %now.", $replacements, WATCHDOG_INFO);
     $queue = DrupalQueue::get('mandrill_incoming');
+    $queue->createQueue();
 
     // If item has been claimed outside of the cron worker callback we need to release it, otherwise throw an error.
     if (isset($item)) {

--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -9,6 +9,46 @@
 // TODO: Make sure the variables for configuration are correct, migrate ws_pm_email_notify to pm_email_notify in all languages
 
 /**
+ * Implements hook_menu().
+ *
+ * Provides an administrative page for Mandrill Incoming.
+ */
+function ws_pm_email_notify_menu() {
+  $items['admin/config/services/mandrill_incoming/queue'] = array(
+    'title' => 'Mandrill Incoming Queue',
+    'description' => 'View and process items in the Mandrill Incoming Queue',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ws_pm_email_notify_admin_settings_form'),
+    'access arguments' => array('administer services'),
+    'weight' => 20,
+  );
+  return $items;
+}
+
+/**
+ * Form providing admin menu options.
+ *
+ * @return array
+ *   An array of form elements for the admin page.
+ */
+function ws_pm_email_notify_admin_settings_form($form, &$form_state) {
+  $form['pm_email_notify_processing'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Manual Processing'),
+    '#weight' => 20,
+  );
+
+  $form['pm_email_notify_processing']['process_item'] = array(
+    '#type' => 'submit',
+    '#value' => t('Process next item'),
+    '#submit' => array('ws_pm_email_notify_queue_claim'),
+  );
+
+  $form = system_settings_form($form);
+  return $form;
+}
+
+/**
  * Alter the outgoing message to use our routing information in subject and headers
  *
  * @param $message
@@ -79,6 +119,81 @@ function ws_pm_email_notify_token_info() {
   return array(
     'tokens' => array('privatemsg_message' => $message),
   );
+}
+
+/**
+ * Insert item into the queue.
+ */
+function ws_pm_email_notify_queue_insert($event, $n = 0) {
+  if (empty($event)) {
+    return FALSE;
+  }
+
+  // Add this item to the queue
+  $record = array(
+    'created' => REQUEST_TIME,
+    'event' => $event,
+  );
+
+  $queue = DrupalQueue::get('mandrill_incoming');
+  $queue->createQueue();
+
+  $queue->createItem($record);
+}
+
+/**
+ * Insert item into the queue.
+ */
+function ws_pm_email_notify_queue_claim($item) {
+  if (empty($item)) {
+    $queue = DrupalQueue::get('digest_queue');
+    $queue->createQueue();
+
+    $item = $queue->claimItem('digest_queue');
+  }
+
+  if (!empty($item->data)) {
+    extract($item->data);
+  } else {
+    return FALSE;
+  }
+
+  // All the logic previously handled in ws_pm_email_notify_mandrill_incoming_event
+  // is now processed by the queue function ws_pm_email_notify_queue_process.
+  $handled = empty($event) ? MANDRILL_INCOMING_UNHANDLED : ws_pm_email_notify_queue_process($event);
+
+  if ($handled === MANDRILL_INCOMING_HANDLED) {
+    watchdog(
+      'mandrill_incoming_queue',
+      "Successfully processed incoming email (to=%to, subject=%subject) at @now. Queue item @item_id",
+      array(
+        '@now' => strftime('%c', strtotime('now')),
+        '@item_id' => $item->item_id,
+        '%to' => print_r($event->msg->to, TRUE),
+        '%subject' => $event->msg->subject,
+      ),
+      WATCHDOG_INFO
+    );
+    $queue->deleteItem($item);
+  } else {
+    // This item was not handled, we need to release it.
+    watchdog(
+      'mandrill_incoming_queue',
+      "An incoming email (to=%to, subject=%subject) has failed processing at %now. Queue item @item_id",
+      array(
+        '@now' => strftime('%c', strtotime('now')),
+        '@item_id' => $item->item_id,
+        '%to' => print_r($event->msg->to, TRUE),
+        '%subject' => $event->msg->subject,
+      ),
+      WATCHDOG_INFO
+    );
+    $queue->releaseItem($item);
+
+    // Notify admin. Possibly
+  }
+
+  return $handled;
 }
 
 
@@ -190,6 +305,21 @@ function ws_pm_email_notify_validate_routing($msg, $mid, $sender_uid, $their_mha
  * @return array|int
  */
 function ws_pm_email_notify_mandrill_incoming_event($event) {
+  // Let's put this item straight into the queue so that we can process later.
+  ws_pm_email_notify_queue_insert($event);
+
+  // We must tell mandrill_incoming that we have successfully handled this event even though we don't know yet.
+  return MANDRILL_INCOMING_HANDLED;
+}
+
+/**
+ * The queue processing function for each item in mandrill_incoming queue.
+ *
+ * @param $event
+ * @return array|int
+ * @throws Exception
+ */
+function ws_pm_email_notify_queue_process($event) {
   $ts = $event->ts; // Consider setting the event ts as the ts of the PM.
   $msg = $event->msg;
 

--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -183,7 +183,7 @@ function ws_pm_email_notify_queue_claim() {
  *  @see https://api.drupal.org/api/drupal/modules!system!system.api.php/function/callback_queue_worker/7
  */
 function ws_pm_email_notify_queue_process($data = NULL) {
-  if(empty($data) {
+  if(empty($data)) {
     $item = ws_pm_email_notify_queue_claim();
     extract($item->data);
   }

--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -121,10 +121,27 @@ function ws_pm_email_notify_token_info() {
   );
 }
 
+/*
+ * Implements hook_cron_queue_info()
+ *
+ * @return array
+ */
+function ws_pm_email_notify_cron_queue_info() {
+  $queues['mandrill_incoming'] = array(
+    'worker callback' => 'ws_pm_email_notify_queue_process',
+    'time' => 20
+  );
+
+  return $queues;
+}
+
 /**
  * Insert item into the queue.
+ *
+ * @param array $event
+ * @return array
  */
-function ws_pm_email_notify_queue_insert($event, $n = 0) {
+function ws_pm_email_notify_queue_insert($event) {
   if (empty($event)) {
     return FALSE;
   }
@@ -143,77 +160,69 @@ function ws_pm_email_notify_queue_insert($event, $n = 0) {
 
 /**
  * Get an item from the queue.
+ *
+ * @return array
  */
 function ws_pm_email_notify_queue_claim() {
   $queue = DrupalQueue::get('mandrill_incoming');
   $queue->createQueue();
 
   $item = $queue->claimItem();
-  return $item->data;
+  return $item;
 }
 
 /**
- * Process items from the queue.
+ * The worker process for the queue
  */
-function ws_pm_email_notify_queue_process($item = NULL) {
-  if (empty($item)) {
-    $item = ws_pm_email_notify_queue_claim();
-  }
 
-  if (!empty($item)) {
-    extract($item);
-  } else {
-    return FALSE;
+/**
+ * Process items from the queue.
+ *
+ * @param array $data | NULL
+ *  Required by the cron worker callback, should not be passed when running outside the cron worker callback.
+ *  @see https://api.drupal.org/api/drupal/modules!system!system.api.php/function/callback_queue_worker/7
+ */
+function ws_pm_email_notify_queue_process($data = NULL) {
+  if(empty($data) {
+    $item = ws_pm_email_notify_queue_claim();
+    extract($item->data);
+  }
+  else {
+    extract($data);
   }
 
   // All the logic previously handled in ws_pm_email_notify_mandrill_incoming_event
   // is now processed by the queue function ws_pm_email_notify_process_event.
   $handled = empty($event) ? MANDRILL_INCOMING_UNHANDLED : ws_pm_email_notify_process_event($event);
 
+  $replacements = array(
+    '@now' => strftime('%c', strtotime('now')),
+    '%to' => print_r($event->msg->to, TRUE),
+    '%subject' => $event->msg->subject,
+  );
+
   if ($handled === MANDRILL_INCOMING_HANDLED) {
-    watchdog(
-      'mandrill_incoming_queue',
-      "Successfully processed incoming email (to=%to, subject=%subject) at @now. Queue item @item_id",
-      array(
-        '@now' => strftime('%c', strtotime('now')),
-        '@item_id' => $item->item_id,
-        '%to' => print_r($event->msg->to, TRUE),
-        '%subject' => $event->msg->subject,
-      ),
-      WATCHDOG_INFO
-    );
+    watchdog('mandrill_incoming_queue', "Successfully processed incoming email (to=%to, subject=%subject) at @now.", $replacements, WATCHDOG_INFO);
     $queue = DrupalQueue::get('mandrill_incoming');
-    $queue->deleteItem($item);
+
+    // If item has been claimed outside of the cron worker callback we need to remove it now, otherwise just continue.
+    if (isset($item)) {
+      $queue->releaseItem($item);
+    }
   } else {
     // This item was not handled, we need to release it.
-    watchdog(
-      'mandrill_incoming_queue',
-      "An incoming email (to=%to, subject=%subject) has failed processing at %now. Queue item @item_id",
-      array(
-        '@now' => strftime('%c', strtotime('now')),
-        '@item_id' => $item->item_id,
-        '%to' => print_r($event->msg->to, TRUE),
-        '%subject' => $event->msg->subject,
-      ),
-      WATCHDOG_INFO
-    );
+    watchdog('mandrill_incoming_queue', "An incoming email (to=%to, subject=%subject) has failed processing at %now.", $replacements, WATCHDOG_INFO);
     $queue = DrupalQueue::get('mandrill_incoming');
-    $queue->releaseItem($item);
 
-    // Notify admin. Possibly
+    // If item has been claimed outside of the cron worker callback we need to release it, otherwise throw an error.
+    if (isset($item)) {
+      $queue->releaseItem($item);
+    } else {
+      throw new Exception(t("An incoming email (to=%to, subject=%subject) has failed processing at %now.", $replacements));
+    }
   }
 
   return $handled;
-}
-
-// hook_cron_queue_info()
-function ws_pm_email_notify_cron_queue_info() {
-  $queues['mandrill_incoming'] = array(
-    'worker callback' => 'ws_pm_email_notify_queue_process',
-    'time' => 20
-  );
-
-  return $queues;
 }
 
 /** Begin section dealing with incoming messages ****/

--- a/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
+++ b/docroot/sites/all/modules/dev/ws_pm_email_notify/ws_pm_email_notify.module
@@ -209,7 +209,7 @@ function ws_pm_email_notify_queue_process($item = NULL) {
 // hook_cron_queue_info()
 function ws_pm_email_notify_cron_queue_info() {
   $queues['mandrill_incoming'] = array(
-    'worker callback' => 'ws_pm_email_notify_queue_claim',
+    'worker callback' => 'ws_pm_email_notify_queue_process',
     'time' => 20
   );
 
@@ -326,6 +326,9 @@ function ws_pm_email_notify_validate_routing($msg, $mid, $sender_uid, $their_mha
 function ws_pm_email_notify_mandrill_incoming_event($event) {
   // Let's put this item straight into the queue so that we can process later.
   ws_pm_email_notify_queue_insert($event);
+
+  // We might as well try to process the next item in the queue to save cron some effort.
+  ws_pm_email_notify_queue_process();
 
   // We must tell mandrill_incoming that we have successfully handled this event even though we don't know yet.
   return MANDRILL_INCOMING_HANDLED;


### PR DESCRIPTION
Added queue processing for mandrill incoming events based on https://github.com/warmshowers/Warmshowers.org/issues/877

This won't directly fix the issue, but should a) allow us to catch and reprocess any errors b) reduce the load when handed batches of mandrill incoming events.

If in fact it is a consistent bug we should be able to catch it in the queue and inspect, if it is the result of a race condition or weird cache loading issue then hopefully it will just go away.

@rfay thanks for the test email :), I've now removed you from the reroute email list, if you are interested in testing you'll need to add yourself back.