### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/docroot/sites/all/modules/contrib/smart_ip/smart_ip.module
+++ b/docroot/sites/all/modules/contrib/smart_ip/smart_ip.module
@@ -18,7 +18,7 @@
 define('SMART_IP_MAXMIND_LITE_BIN_DOWNLOAD_BASE_URL', 'http://geolite.maxmind.com/download/geoip/database');
 define('SMART_IP_MAXMIND_LITE_CSV_DOWNLOAD_BASE_URL', 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV');
 define('SMART_IP_MAXMIND_GEOIP_BASE_URL', 'https://geoip.maxmind.com');
-define('SMART_IP_MAXMIND_BIN_DOWNLOAD_BASE_URL', 'http://download.maxmind.com/app/geoip_download');
+define('SMART_IP_MAXMIND_BIN_DOWNLOAD_BASE_URL', 'https://download.maxmind.com/app/geoip_download');
 define('SMART_IP_MAXMIND_LOCATION_CSV', 'Location.csv');
 define('SMART_IP_MAXMIND_BLOCKS_CSV', 'Blocks.csv');
 define('SMART_IP_MAXMIND_BIN_DB_NAME', 'GeoIP');


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).